### PR TITLE
docs: record public collaboration and security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Supported version
+
+Security fixes apply to the current `main` branch. Historical commits and
+external formalizations are retained as research evidence and are not supported
+software releases.
+
+## Reporting a vulnerability
+
+Use GitHub's
+[private vulnerability reporting](https://github.com/mbrcic/ai-safety-formalization-atlas/security/advisories/new)
+for security or privacy-sensitive reports. Do not disclose credentials,
+personal data, or exploitable details in a public issue.
+
+For mathematical errors, provenance problems, build failures, or incorrect
+coverage claims that are safe to discuss publicly, use the repository's problem
+report issue form instead.

--- a/STATE.md
+++ b/STATE.md
@@ -1,7 +1,7 @@
 # Project State
 
 Updated: 2026-07-18
-Current phase: public collaboration preparation
+Current phase: public collaboration
 
 ## Completed
 
@@ -14,12 +14,12 @@ Current phase: public collaboration preparation
 - Reviewed AI-system bridge theorems: 0
 - v0.1 publication approved through `e9fdfc0`
 - Squashed v0.1 baseline published on `main`
+- Public metadata, security reporting, and protected `main` rules configured
 
 ## Current work
 
-- Add a minimal contributor workflow and public repository metadata.
-- Configure GitHub branch rules after visibility changes.
 - Invite focused contributions through the public strategy and roadmap.
+- Triage source-verification, API-review, and bridge-design proposals.
 
 ## Blocked
 

--- a/scripts/audit_release.py
+++ b/scripts/audit_release.py
@@ -23,6 +23,7 @@ def main() -> None:
         "README.md",
         "CONTRIBUTING.md",
         "CITATION.cff",
+        "SECURITY.md",
         "LICENSE",
         "STATE.md",
         "registry.yaml",


### PR DESCRIPTION
## Summary

- record that the repository is public and `main` is protected
- add a security policy using GitHub private vulnerability reporting
- make the release audit require the security policy

## Validation

- `python3 scripts/validate_registry.py`
- `python3 scripts/audit_release.py`
- `lake build` (903 jobs)