### PR TITLE
ci: reduce Dependabot update frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,9 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: monthly
+      interval: cron
+      cronjob: "0 9 1 1,5,9 *"
+      timezone: Europe/Zagreb
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
Changes scheduled GitHub Actions version-update checks from monthly to every four months: January 1, May 1, and September 1 at 09:00 Europe/Zagreb time. Security alerts remain independent of this version-update schedule.