### PR TITLE
chore: harden onboarding — quick mode, installer robustness, CI smoke-test, Codespaces badge

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "features": {
     "ghcr.io/devcontainers/features/python:1": {}
   },
-  "onCreateCommand": "bash scripts/setup.sh",
+  "onCreateCommand": "bash scripts/setup.sh --quick",
   "remoteEnv": {
     "PATH": "${containerEnv:HOME}/.elan/bin:${containerEnv:PATH}"
   },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,19 @@ jobs:
           persist-credentials: false
       - name: Cheap agent gate
         run: ./scripts/agent_gate.sh
+      # Onboarding contract: setup.sh must parse, document itself, reject bad
+      # options, and run the docs-only (--pointer) path. This job is unfiltered,
+      # so a PR that breaks the onboarding script can no longer stay green.
+      - name: Smoke-test onboarding (setup.sh contract)
+        run: |
+          set -euo pipefail
+          bash -n scripts/setup.sh
+          scripts/setup.sh --help >/dev/null
+          if scripts/setup.sh --bogus >/dev/null 2>&1; then
+            echo "setup.sh accepted an unknown option — expected non-zero exit" >&2
+            exit 1
+          fi
+          scripts/setup.sh --pointer
 
   # Lean build + axioms only when Lean toolchain or sources change.
   lean:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # AI Safety Formalization Atlas
 
 [![CI](https://github.com/mbrcic/ai-safety-formalization-atlas/actions/workflows/ci.yml/badge.svg)](https://github.com/mbrcic/ai-safety-formalization-atlas/actions/workflows/ci.yml)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/mbrcic/ai-safety-formalization-atlas)
+
+> **Quickstart:** [Open in Codespaces](https://codespaces.new/mbrcic/ai-safety-formalization-atlas) — the toolchain provisions itself and one example compiles in minutes — then pick a [first task](docs/guide/contributor-tasks.md#open-now). Prefer local? `scripts/setup.sh --pointer` (docs only, no Lean) or `scripts/setup.sh --quick` (one example). Full detail: [Get started](#get-started).
 
 **The open workbench for doing AI safety the formal way.**
 
@@ -175,12 +178,14 @@ Then add a lead under that row's `candidate_formalizations` in
 prebuilt Mathlib, builds, and runs the validators:
 
 ```console
-scripts/setup.sh
+scripts/setup.sh --quick   # fast path: toolchain + Mathlib cache + one example compiling
+scripts/setup.sh           # full: whole build closure + validators (run before a Lean PR)
 ```
 
 Zero local install: open the repo in **GitHub Codespaces** — or any editor's
 [Dev Container](.devcontainer/devcontainer.json) — and the toolchain provisions
-itself on first boot.
+itself on first boot (via `--quick`, so the cold start stays short; run the full
+`scripts/setup.sh` before submitting a Lean change).
 
 <details>
 <summary>What <code>scripts/setup.sh</code> runs, to do it by hand</summary>

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,11 +2,12 @@
 # One-shot onboarding bootstrap for the AI Safety Formalization Atlas.
 #
 #   scripts/setup.sh            full proof setup: elan + prebuilt Mathlib + build + validators
+#   scripts/setup.sh --quick    fast first compile: elan + Mathlib cache + one small example
 #   scripts/setup.sh --pointer  docs/registry only: skip the Lean toolchain, run cheap validators
 #
-# Idempotent and safe to re-run. Installs elan only when `lake` is missing;
-# the toolchain version is taken from `lean-toolchain`, dependencies from the
-# committed `lake-manifest.json` (never `lake update`).
+# Idempotent and safe to re-run. Installs elan only when neither `elan` nor
+# `lake` is present; the toolchain version is taken from `lean-toolchain`,
+# dependencies from the committed `lake-manifest.json` (never `lake update`).
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -15,6 +16,7 @@ cd "$ROOT"
 MODE="full"
 for arg in "$@"; do
   case "$arg" in
+    --quick) MODE="quick" ;;
     --pointer|--no-lean) MODE="pointer" ;;
     -h|--help) awk 'NR>1 && /^#/{sub(/^# ?/,"");print;next} NR>1{exit}' "$0"; exit 0 ;;
     *) echo "unknown option: $arg (try --help)" >&2; exit 2 ;;
@@ -23,10 +25,14 @@ done
 
 need() { command -v "$1" >/dev/null 2>&1; }
 
-if ! need python3; then
-  echo "error: python3 is required — the validators are pure-stdlib Python 3." >&2
-  exit 1
-fi
+require() {  # require <cmd> <why>
+  if ! need "$1"; then
+    echo "error: '$1' is required — $2" >&2
+    exit 1
+  fi
+}
+
+require python3 "the validators are pure-stdlib Python 3."
 
 if [ "$MODE" = "pointer" ]; then
   echo "==> pointer mode: skipping the Lean toolchain"
@@ -38,7 +44,11 @@ if [ "$MODE" = "pointer" ]; then
 fi
 
 # --- Lean toolchain (elan) ---
-if ! need lake; then
+# Gate on elan, not just lake: elan is what honors `lean-toolchain`. A stray
+# non-elan `lake` on PATH would pin a different toolchain, so only skip the
+# install when elan (or a lake) is already present.
+if ! need elan && ! need lake; then
+  require curl "needed to download the elan installer."
   echo "==> installing elan (Lean toolchain manager)"
   curl -fsSL https://elan.lean-lang.org/elan-init.sh | sh -s -- -y --default-toolchain none
 fi
@@ -49,19 +59,29 @@ if [ -f "$HOME/.elan/env" ]; then
   . "$HOME/.elan/env"
 fi
 
-if ! need lake; then
-  echo "error: 'lake' is still not on PATH after installing elan." >&2
-  echo "Open a new shell (or run '. ~/.elan/env') and re-run scripts/setup.sh." >&2
-  exit 1
-fi
+require lake "'lake' is not on PATH after installing elan — open a new shell (or run '. ~/.elan/env') and re-run scripts/setup.sh."
+
+echo "==> selected Lean toolchain: $(cat lean-toolchain)"
+lake --version
 
 echo "==> fetching prebuilt Mathlib (lake exe cache get)"
 lake exe cache get
+
+if [ "$MODE" = "quick" ]; then
+  echo "==> quick build: one small Foundation-free example (AISafetyAtlas.Examples.NFLConcrete)"
+  lake build AISafetyAtlas.Examples.NFLConcrete
+  echo
+  echo "setup: ok (quick). One example compiles — the toolchain works."
+  echo "Before opening a PR that touches Lean, run the full setup: scripts/setup.sh"
+  echo "Pick a bounded unit: docs/guide/contributor-tasks.md#open-now"
+  exit 0
+fi
 
 echo "==> lake build"
 lake build
 
 echo "==> building explicit targets (scripts/lean_build_targets.txt)"
+require xargs "needed to build the explicit non-root targets."
 xargs lake build < scripts/lean_build_targets.txt
 
 echo "==> cheap validators (scripts/agent_gate.sh)"


### PR DESCRIPTION
Deterministic items from an external onboarding review (Batch A). No new library capital — friction + contract-safety only.

## #2 `setup.sh --quick`
Fast first compile: elan + Mathlib cache + one small **Foundation-free** example (`AISafetyAtlas.Examples.NFLConcrete`), skipping the full build closure. Codespaces `onCreateCommand` now uses `--quick` so cold start stays short; the full `scripts/setup.sh` remains the pre-PR verification path.

## #5 Installer robustness
- Gate the elan install on **`elan`** (not just `lake`) — a stray non-elan `lake` on PATH could silently pin a different toolchain, weakening the `lean-toolchain` guarantee.
- Explicit `curl` / `xargs` presence checks with clear errors.
- Print the selected `lean-toolchain` + `lake --version` before building.

## #3 CI smoke-tests the onboarding contract
New step in the **always-on** `agent-gate` job: `bash -n`, `--help`, unknown-option rejection, and `--pointer` end-to-end. The job is unfiltered, so a PR that breaks `setup.sh` can no longer merge green.

**Deliberate deviation from the review:** did *not* add `setup.sh` / `.devcontainer/**` to the lean-build path filter. A shell/devcontainer change doesn't warrant a multi-GB Mathlib rebuild, and the lean job wouldn't exercise `setup.sh` anyway — it would add cost, not coverage. A clean-machine dev-container build stays a future scheduled job.

## #4 Conversion
- **Open in Codespaces** badge beside the CI badge.
- Three-line quickstart at the top: launch → compile → first task.
- `--quick` surfaced in Get started.

## Not in this PR (Batch B, needs curation)
Review item #1 — the actual bottleneck: three S-sized first tasks + one compiling starter file. That is content/curation, tracked separately.

## Verification
- `bash -n scripts/setup.sh` clean; `--help` lists `--quick`; unknown option exits 2; `--pointer` runs `agent_gate` green; quick target file present.
- 4 files, +54/-16.