### PR TITLE
docs: Batch B — S-sized first tasks, discovery channel, Codespaces polish

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,12 +5,14 @@
     "ghcr.io/devcontainers/features/python:1": {}
   },
   "onCreateCommand": "bash scripts/setup.sh --quick",
+  "postAttachCommand": "echo '' && echo 'Ready. Toolchain provisioned and one example compiled.' && echo 'Pick a first task: docs/guide/contributor-tasks.md#open-now' && echo 'Before a Lean PR, run the full setup: scripts/setup.sh'",
   "remoteEnv": {
     "PATH": "${containerEnv:HOME}/.elan/bin:${containerEnv:PATH}"
   },
   "customizations": {
     "vscode": {
-      "extensions": ["leanprover.lean4"]
+      "extensions": ["leanprover.lean4"],
+      "openFiles": ["docs/guide/contributor-tasks.md"]
     }
   }
 }

--- a/.github/ISSUE_TEMPLATE/known-formalization.yml
+++ b/.github/ISSUE_TEMPLATE/known-formalization.yml
@@ -1,0 +1,64 @@
+name: Known formalization / proof we don't have
+description: Point us at a result — or a proof of one — that isn't in the catalogue yet. No Lean or proof required.
+title: "[Discovery]: "
+labels: ["discovery"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        You know a result, or a proof of one, that the Atlas doesn't record. Tell us where it lives — that's a real contribution on its own. We reproduce or classify it; you don't have to.
+
+        This never claims coverage by itself. A lead becomes coverage only after the proof is reproduced and classified. Please check `registry.yaml`, `landscape.yaml`, and open issues first.
+  - type: input
+    id: result
+    attributes:
+      label: Result
+      description: The theorem or claim. Give the BY identifier if it maps to a survey row, otherwise name it precisely.
+      placeholder: "BY-021 — No Free Lunch (optimization), or: Blum speed-up theorem"
+    validations:
+      required: true
+  - type: dropdown
+    id: readiness
+    attributes:
+      label: Readiness tier
+      description: How far along is the proof you know about?
+      options:
+        - Lean — already formalized in Lean (Mathlib, an upstream dev, anywhere)
+        - Other prover — formalized in Isabelle/AFP, Coq/Rocq, HOL, Agda, etc.
+        - Pen and paper — a complete informal proof exists, not yet mechanized
+    validations:
+      required: true
+  - type: textarea
+    id: coordinates
+    attributes:
+      label: Source coordinates
+      description: |
+        Where exactly does it live? Give as much as applies:
+        - Lean / other prover: repository URL, an immutable revision (commit SHA / AFP release), file, and declaration name.
+        - Pen and paper: paper title, authors, venue/year, DOI or arXiv id, and the exact theorem number.
+      placeholder: |
+        github.com/owner/repo @ <commit sha>, path/to/File.lean, theorem_name
+        — or —
+        Author et al., "Title", Venue 20XX, arXiv:XXXX.XXXXX, Theorem 3.2
+    validations:
+      required: true
+  - type: input
+    id: license
+    attributes:
+      label: License
+      description: For an existing formalization, the license of the source repository (needed before reproduction/vendoring).
+      placeholder: "Apache-2.0 / MIT / unknown"
+  - type: textarea
+    id: relevance
+    attributes:
+      label: Why it's interesting
+      description: One or two lines — how it connects to AI safety, or which survey row / open task it would serve.
+  - type: checkboxes
+    id: policy
+    attributes:
+      label: Checks
+      options:
+        - label: I searched registry.yaml, landscape.yaml, and open issues; this isn't already recorded.
+          required: true
+        - label: I understand a lead is candidate evidence, not verified coverage, until reproduced and classified.
+          required: true

--- a/AISafetyAtlas/Examples/FirstContribution.lean
+++ b/AISafetyAtlas/Examples/FirstContribution.lean
@@ -1,0 +1,66 @@
+module
+
+import AISafetyAtlas.Learning
+
+/-!
+# First contribution — a copyable starter
+
+A minimal, self-contained file for your first Lean change (task **CT-13**,
+`docs/guide/contributor-tasks.md#open-now`). It compiles as-is, so you can copy
+it, add one line, and watch CI stay green.
+
+Everything here is Foundation-free: it imports only `AISafetyAtlas.Learning`, so
+it builds under the fast `scripts/setup.sh --quick` path — no full Gödel build
+needed. The stable public facade is the single root import:
+
+```lean
+import AISafetyAtlas
+```
+
+Bring your own theorem in over that root when you graduate to the headline
+surface (Rice, Arrow, Gödel, Löb — see the README "Lean API" section). Here we
+stay on the learning layer to keep the starter light.
+-/
+
+open AISafetyAtlas.Learning
+
+namespace AISafetyAtlas.Examples.FirstContribution
+
+/-- Train on `{0}` only. -/
+def trainOn0 : Set (Fin 2) := {0}
+
+/-- Constant-0 learner. -/
+def learnerConst0 : SupervisedLearner (Fin 2) (Fin 2) trainOn0 :=
+  fun _ _ => 0
+
+/-- Constant-1 learner. -/
+def learnerConst1 : SupervisedLearner (Fin 2) (Fin 2) trainOn0 :=
+  fun _ _ => 1
+
+/--
+Two different learners have equal aggregate off-training-set loss — a concrete
+instance of `no_free_lunch_supervised`. This uses the shipped theorem; it does
+not reprove it.
+-/
+example :
+    aggregateOffTrainingLoss trainOn0 learnerConst0 =
+      aggregateOffTrainingLoss trainOn0 learnerConst1 :=
+  no_free_lunch_supervised trainOn0 learnerConst0 learnerConst1
+
+/-
+YOUR TURN (CT-13, difficulty S)
+-------------------------------
+Add ONE new `example` below that exercises an existing shipped theorem — no new
+math, just a use-site. Ideas:
+
+  * a third constant learner and another `no_free_lunch_supervised` instance;
+  * a `no_free_lunch` instance over cost-sequence schedules
+    (see `AISafetyAtlas.Examples.NFLConcrete` for the pattern);
+  * anything from the README "Lean API" list, after switching to `import
+    AISafetyAtlas`.
+
+Then: `lake build AISafetyAtlas.Examples.FirstContribution` must be green and
+`python3 scripts/check_print_axioms.py` must stay clean. Open a pull request.
+-/
+
+end AISafetyAtlas.Examples.FirstContribution

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # AI Safety Formalization Atlas
 
 [![CI](https://github.com/mbrcic/ai-safety-formalization-atlas/actions/workflows/ci.yml/badge.svg)](https://github.com/mbrcic/ai-safety-formalization-atlas/actions/workflows/ci.yml)
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/mbrcic/ai-safety-formalization-atlas)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/mbrcic/ai-safety-formalization-atlas?quickstart=1)
 
-> **Quickstart:** [Open in Codespaces](https://codespaces.new/mbrcic/ai-safety-formalization-atlas) — the toolchain provisions itself and one example compiles in minutes — then pick a [first task](docs/guide/contributor-tasks.md#open-now). Prefer local? `scripts/setup.sh --pointer` (docs only, no Lean) or `scripts/setup.sh --quick` (one example). Full detail: [Get started](#get-started).
+> **Quickstart:** [Open in Codespaces](https://codespaces.new/mbrcic/ai-safety-formalization-atlas?quickstart=1) — the toolchain provisions itself and one example compiles in minutes — then pick a [first task](docs/guide/contributor-tasks.md#open-now). Prefer local? `scripts/setup.sh --pointer` (docs only, no Lean) or `scripts/setup.sh --quick` (one example). Full detail: [Get started](#get-started).
 
 **The open workbench for doing AI safety the formal way.**
 

--- a/docs/guide/contributor-tasks.md
+++ b/docs/guide/contributor-tasks.md
@@ -15,6 +15,58 @@ Live units across the contribution rungs. Take one, open the matching proposal
 issue, or ask in a draft PR. CT-1…CT-5 below are completed history, kept for
 provenance.
 
+**New here? Start with an S.** CT-11…CT-14 are first tasks — one sitting, no
+prior context, a single deterministic done-check. Take one, then climb.
+
+### CT-11 — Add a candidate lead to an uncovered row (S) — **Pointer rung**
+
+- **Goal:** pick one `MAPPED`-only survey row in [`registry.yaml`](../../registry.yaml)
+  whose `candidate_formalizations` is `[]`, and add **one** lead — a repository
+  or paper URL that plausibly formalizes or proves it. No Lean, no proof, no
+  coverage claim.
+- **Acceptance:** a schema-valid `candidate_formalizations` entry;
+  `scripts/setup.sh --pointer` (i.e. `scripts/agent_gate.sh`) green. A lead is
+  candidate evidence, not coverage.
+- **Does not change:** the row's `status` or any coverage count — a candidate is
+  not a formalization until reproduced and classified.
+
+### CT-12 — Verify one citation against its source (S) — **Verification rung**
+
+- **Goal:** take one `original_source_refs` entry in
+  [`registry.yaml`](../../registry.yaml) — e.g. `survey-ref-018` (doi
+  `10.1162/neco.1996.8.7.1391`) — confirm the DOI/arXiv id resolves to the cited
+  paper and that the transcribed title, authors, and pages match. Correct the
+  entry if anything is off.
+- **Acceptance:** either "verified, no change" recorded in the PR description
+  with the resolved link, or a precise transcription fix; `scripts/agent_gate.sh`
+  green. Source verification is a first-class contribution.
+- **Does not change:** any Lean, any relationship classification.
+
+### CT-13 — Add one Lean use-site over a shipped theorem (S) — **New-proof rung, scoped**
+
+- **Goal:** copy [`AISafetyAtlas/Examples/FirstContribution.lean`](../../AISafetyAtlas/Examples/FirstContribution.lean)
+  as your model and add one new `example` that exercises an existing shipped
+  theorem (e.g. `no_free_lunch_supervised`, or anything on the README "Lean API"
+  list over `import AISafetyAtlas`). No new math — a use-site, not a reproof.
+- **Acceptance:** `lake build AISafetyAtlas.Examples.FirstContribution` (or
+  `.PublicAPI`) green; `python3 scripts/check_print_axioms.py` clean. Runs under
+  the fast `scripts/setup.sh --quick` path if you stay on the learning layer.
+- **Does not change:** any theorem statement or the public facade.
+
+### CT-14 — Report a proof we don't have (S) — **Pointer rung**
+
+- **Goal:** you know a result — or a proof of one — not in the catalogue. Report
+  where it lives, via the [Known formalization issue form](https://github.com/mbrcic/ai-safety-formalization-atlas/issues/new?template=known-formalization.yml).
+  Value grades by readiness: **pen and paper** (a formalization target) →
+  **another prover** (an Isabelle/Coq/HOL reproduction candidate) → **already in
+  Lean** (a possible thin vendor/alias). This is the reuse thesis as a rung:
+  point us at a building block instead of reinventing it.
+- **Acceptance:** a filled discovery issue, or a schema-valid
+  `candidate_formalizations` entry with source coordinates and license;
+  `scripts/agent_gate.sh` green if you touch the registry. No coverage claimed
+  until reproduced and classified.
+- **Does not change:** any coverage count — a lead is candidate evidence only.
+
 ### CT-6 — First possibility proof: continuous free lunches (BY-022) (L) — **New proof rung**
 
 - **Goal:** give BY-022 (*Free lunches in continuous spaces and coevolution*,

--- a/scripts/lean_build_targets.txt
+++ b/scripts/lean_build_targets.txt
@@ -2,4 +2,5 @@ AISafetyAtlas.Examples.PublicAPI
 AISafetyAtlas.Examples.Registry
 AISafetyAtlas.Examples.Robot
 AISafetyAtlas.Examples.NFLConcrete
+AISafetyAtlas.Examples.FirstContribution
 AISafetyAtlas.Survey.BrcicYampolskiy.HaltingExample


### PR DESCRIPTION
Fills the missing lowest rung on the contribution ladder. Before this, `docs/guide/contributor-tasks.md#open-now` held only **L/M** tasks — a newcomer's first available unit was a graduate-level Lean proof. This adds four **S** tasks (one sitting, no prior context, a single deterministic done-check) plus the files that back them.

## First tasks (CT-11…CT-14)

- **CT-11 Pointer** — add one candidate lead to a `MAPPED`-only registry row. Done-check: `scripts/setup.sh --pointer` green.
- **CT-12 Verification** — source-check one citation's DOI/title/pages against the paper. Done-check: `agent_gate.sh` green.
- **CT-13 Lean use-site** — add one `example` over a shipped theorem. Done-check: `lake build …FirstContribution` green, axioms clean.
- **CT-14 Discovery** — *report a proof we don't have* (pen&paper → other-prover → Lean readiness tiers). The reuse thesis as a rung: point at a building block instead of reinventing it.

## Supporting files

- `AISafetyAtlas/Examples/FirstContribution.lean` — compiling copy-target for CT-13. Foundation-free (imports only `AISafetyAtlas.Learning`), so it builds under `setup.sh --quick`. Its worked `example` is the shipped `no_free_lunch_supervised`; the rest is a commented "your turn" block. Added to `scripts/lean_build_targets.txt` so CI keeps it green.
- `.github/ISSUE_TEMPLATE/known-formalization.yml` — issue form backing CT-14 (result, readiness tier, source coordinates, license, non-coverage acknowledgement).
- **Codespaces polish:** `?quickstart=1` on the badge + quickstart URLs; devcontainer `postAttachCommand` ready-banner and auto-open of the task list on first boot.

## Verification

- `scripts/agent_gate.sh` green, including the docs-path check (182 links / 30 files).
- `lake build AISafetyAtlas.Examples.FirstContribution` → `1007/1007`, built locally.
- `known-formalization.yml` and `devcontainer.json` parse clean.

## Not in this PR (Batch C)

The conjecture channel — a `sorry`-typecheck admission gate, `conjectures.yaml` quarantine, and promotion policy — is deferred to its own PR so its spam-hardening is reviewed as a unit.

## Note for the maintainer

The one Codespaces win only you can flip: **enable Prebuilds** (repo Settings → Codespaces) so the badge opens a ready container in seconds instead of running `--quick` cold on each launch. Everything in this PR is the in-repo half.