### PR TITLE
fix(onboarding): Codespaces namespace, elan guard, quick target, CT acceptance

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,8 +11,13 @@
   },
   "customizations": {
     "vscode": {
-      "extensions": ["leanprover.lean4"],
-      "openFiles": ["docs/guide/contributor-tasks.md"]
+      "extensions": ["leanprover.lean4"]
+    },
+    "codespaces": {
+      "openFiles": [
+        "AISafetyAtlas/Examples/FirstContribution.lean",
+        "docs/guide/contributor-tasks.md"
+      ]
     }
   }
 }

--- a/docs/guide/contributor-tasks.md
+++ b/docs/guide/contributor-tasks.md
@@ -67,6 +67,45 @@ prior context, a single deterministic done-check. Take one, then climb.
   until reproduced and classified.
 - **Does not change:** any coverage count — a lead is candidate evidence only.
 
+### CT-15 — Formalize the survey's own three theorems (BY-042 / BY-043 / BY-044) (L) — **New proof rung**
+
+The three results the survey [*Impossibility Results in AI: A Survey*](https://doi.org/10.1145/3603371)
+introduces **itself** — presented with proof sketches in a dedicated section,
+distinct from the Table-1 catalogue of others' results. Each is `PROOF_SKETCH`,
+`MAPPED`, and unformalized. This is the highest-legitimacy native target in the
+ledger: the authors' own sketched theorem turned into a machine-checked one,
+dual to CT-6 but in-house. A sketch is a scaffold, not a full proof —
+mechanizing it audits the sketch.
+
+- **Targets (pick one):**
+  - **BY-044 — Limited self-awareness:** an agent cannot be perfectly
+    self-aware across the survey's operational boundaries. Sketch likely rests on
+    self-reference / a fixed-point argument — check reuse of the atlas's Gödel,
+    Rice, and halting layers before building primitives.
+  - **BY-043 — Misaligned embodiment:** mistakenly cloned self-interested agents
+    cannot perfectly control one another. Likely an uncontrollability /
+    self-reference argument — same reuse check.
+  - **BY-042 — Unfairness of explainability:** a verifier and a decision-maker
+    hold structurally unequal strategic positions when explanations omit the full
+    execution trace. Likely game-theoretic / information-asymmetry — expect new
+    machinery; scope the hardest, take last.
+- **Step 0 (do first, low effort):** in [`registry.yaml`](../../registry.yaml)
+  set the chosen row's `original_source_refs` to the survey itself
+  (`10.1145/3603371`) — these are survey-original results and the field is
+  currently empty — and write a provenance note under
+  [`../provenance/`](../provenance/) that pins the **exact** paper statement,
+  section/theorem number, the sketch, and every definition it assumes
+  (e.g. what "perfectly self-aware" or "operational boundaries" mean formally).
+  Pin the model before writing Lean.
+- **Acceptance:** a kernel-checked Lean theorem under the facade (new namespace as
+  needed — `AISafetyAtlas.SelfAwareness`, `.Embodiment`; `.Explainability`
+  already exists) with an honest `EXACT`/`EQUIVALENT`/`RELATED` classification
+  against the paper statement; the provenance note stating exactly which
+  assumptions are and are not mechanized and **any gap the sketch leaves**;
+  `agent_gate.sh` + `lake build` green; kernel axioms clean.
+- **Does not change:** the other two rows until each lands; no retro-claim of
+  coverage in README/registry until a proof (not a statement) is in.
+
 ### CT-6 — First possibility proof: continuous free lunches (BY-022) (L) — **New proof rung**
 
 - **Goal:** give BY-022 (*Free lunches in continuous spaces and coevolution*,

--- a/docs/guide/contributor-tasks.md
+++ b/docs/guide/contributor-tasks.md
@@ -37,20 +37,25 @@ prior context, a single deterministic done-check. Take one, then climb.
   `10.1162/neco.1996.8.7.1391`) — confirm the DOI/arXiv id resolves to the cited
   paper and that the transcribed title, authors, and pages match. Correct the
   entry if anything is off.
-- **Acceptance:** either "verified, no change" recorded in the PR description
-  with the resolved link, or a precise transcription fix; `scripts/agent_gate.sh`
-  green. Source verification is a first-class contribution.
+- **Acceptance:** every outcome leaves a durable record. Found a mismatch? Open
+  a PR with the precise transcription fix (`scripts/agent_gate.sh` green). Checks
+  out clean? Report it on the row's tracking issue (or a new verification issue)
+  with the resolved link and what you confirmed — no empty PR. Source
+  verification is a first-class contribution.
 - **Does not change:** any Lean, any relationship classification.
 
-### CT-13 — Add one Lean use-site over a shipped theorem (S) — **New-proof rung, scoped**
+### CT-13 — Add one Lean use-site over a shipped theorem (S) — **API use-site rung**
 
 - **Goal:** copy [`AISafetyAtlas/Examples/FirstContribution.lean`](../../AISafetyAtlas/Examples/FirstContribution.lean)
   as your model and add one new `example` that exercises an existing shipped
   theorem (e.g. `no_free_lunch_supervised`, or anything on the README "Lean API"
   list over `import AISafetyAtlas`). No new math — a use-site, not a reproof.
 - **Acceptance:** `lake build AISafetyAtlas.Examples.FirstContribution` (or
-  `.PublicAPI`) green; `python3 scripts/check_print_axioms.py` clean. Runs under
-  the fast `scripts/setup.sh --quick` path if you stay on the learning layer.
+  `.PublicAPI`) green and `scripts/agent_gate.sh` clean. A non-public `example`
+  needs no local axiom audit — CI runs `check_print_axioms.py` over the headline
+  surface for you; reserve that check for new *public* theorems and bridges.
+  Runs under the fast `scripts/setup.sh --quick` path if you stay on the learning
+  layer.
 - **Does not change:** any theorem statement or the public facade.
 
 ### CT-14 — Report a proof we don't have (S) — **Pointer rung**

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -5,9 +5,10 @@
 #   scripts/setup.sh --quick    fast first compile: elan + Mathlib cache + one small example
 #   scripts/setup.sh --pointer  docs/registry only: skip the Lean toolchain, run cheap validators
 #
-# Idempotent and safe to re-run. Installs elan only when neither `elan` nor
-# `lake` is present; the toolchain version is taken from `lean-toolchain`,
-# dependencies from the committed `lake-manifest.json` (never `lake update`).
+# Idempotent and safe to re-run. Installs elan whenever `elan` itself is
+# missing (elan is what honors `lean-toolchain`); the toolchain version is taken
+# from `lean-toolchain`, dependencies from the committed `lake-manifest.json`
+# (never `lake update`).
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -44,10 +45,10 @@ if [ "$MODE" = "pointer" ]; then
 fi
 
 # --- Lean toolchain (elan) ---
-# Gate on elan, not just lake: elan is what honors `lean-toolchain`. A stray
-# non-elan `lake` on PATH would pin a different toolchain, so only skip the
-# install when elan (or a lake) is already present.
-if ! need elan && ! need lake; then
+# Gate on elan, not lake: elan is what honors `lean-toolchain`. A stray non-elan
+# `lake` on PATH would pin a different toolchain, so a present `lake` must not
+# suppress the elan install — key only on elan's own absence.
+if ! need elan; then
   require curl "needed to download the elan installer."
   echo "==> installing elan (Lean toolchain manager)"
   curl -fsSL https://elan.lean-lang.org/elan-init.sh | sh -s -- -y --default-toolchain none
@@ -68,8 +69,8 @@ echo "==> fetching prebuilt Mathlib (lake exe cache get)"
 lake exe cache get
 
 if [ "$MODE" = "quick" ]; then
-  echo "==> quick build: one small Foundation-free example (AISafetyAtlas.Examples.NFLConcrete)"
-  lake build AISafetyAtlas.Examples.NFLConcrete
+  echo "==> quick build: the newcomer starter (AISafetyAtlas.Examples.FirstContribution)"
+  lake build AISafetyAtlas.Examples.FirstContribution
   echo
   echo "setup: ok (quick). One example compiles — the toolchain works."
   echo "Before opening a PR that touches Lean, run the full setup: scripts/setup.sh"


### PR DESCRIPTION
External review flagged six onboarding defects; all six confirmed against the tree and fixed.

## Fixes
1. **Codespaces `openFiles` namespace** — was under `customizations.vscode` (silently ignored); moved to `customizations.codespaces`. Now opens the starter file + tasks doc on boot.
2. **Elan guard** — `if ! need elan && ! need lake` skipped install when a stray non-elan `lake` was on PATH, contradicting the comment's own "gate on elan, not lake" intent. Now keys on `! need elan` alone.
3. **`--quick` target** — built `NFLConcrete`, not the newcomer starter. Now builds `AISafetyAtlas.Examples.FirstContribution`, the file CT-13 tells contributors to copy — so the quick path actually demonstrates the starter compiles. Verified: `Build completed successfully (1007 jobs)`.
4. **CT-13 rung label** — renamed "New-proof rung" → "API use-site rung" (the task explicitly has no new math); dropped the local `check_print_axioms.py` requirement (a non-public `example` needs no headline axiom audit — CI covers it), acceptance is now `lake build` + `agent_gate.sh`.
5. **CT-12 empty-PR path** — "verified, no change recorded in the PR description" cannot produce a mergeable diff. Reworded so every outcome leaves a durable artifact: correction → PR; clean → verification issue with the resolved link.
6. **`discovery` label** — the `known-formalization.yml` form requested a label that did not exist (silently dropped). Created `discovery`.

## Not in this PR
- Files unchanged beyond the four above; no schema changes.