### PR TITLE
docs: Zenodo DOI badge + CITATION identifiers

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,6 +8,13 @@ authors:
     orcid: "https://orcid.org/0000-0002-7564-6805"
 version: "0.3.1"
 date-released: 2026-07-22
+identifiers:
+  - type: doi
+    value: "10.5281/zenodo.21483033"
+    description: "Concept DOI (all versions)"
+  - type: doi
+    value: "10.5281/zenodo.21483034"
+    description: "Version DOI (v0.3.1)"
 repository-code: "https://github.com/mbrcic/ai-safety-formalization-atlas"
 url: "https://github.com/mbrcic/ai-safety-formalization-atlas"
 license: Apache-2.0

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/mbrcic/ai-safety-formalization-atlas/actions/workflows/ci.yml/badge.svg)](https://github.com/mbrcic/ai-safety-formalization-atlas/actions/workflows/ci.yml)
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/mbrcic/ai-safety-formalization-atlas?quickstart=1)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21483033.svg)](https://doi.org/10.5281/zenodo.21483033)
 
 > **Quickstart:** [Open in Codespaces](https://codespaces.new/mbrcic/ai-safety-formalization-atlas?quickstart=1) — the toolchain provisions itself and one example compiles in minutes — then pick a [first task](docs/guide/contributor-tasks.md#open-now). Prefer local? `scripts/setup.sh --pointer` (docs only, no Lean) or `scripts/setup.sh --quick` (one example). Full detail: [Get started](#get-started).
 


### PR DESCRIPTION
The v0.3.1 GitHub Release was archived to Zenodo. Wiring the **concept DOI** (all-versions, always resolves to latest) into the two places that cite the software.

## Changes
- **README**: DOI badge next to CI / Codespaces → `10.5281/zenodo.21483033`.
- **CITATION.cff**: `identifiers:` block with both DOIs:
  - `10.5281/zenodo.21483033` — Concept DOI (all versions)
  - `10.5281/zenodo.21483034` — Version DOI (v0.3.1)

Badge and citation point at the **concept** DOI so they never need updating per release; the version DOI is recorded for provenance.

agent_gate green.