### PR TITLE
docs: top-level doi in CITATION.cff for the GitHub cite widget

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,6 +8,7 @@ authors:
     orcid: "https://orcid.org/0000-0002-7564-6805"
 version: "0.3.1"
 date-released: 2026-07-22
+doi: "10.5281/zenodo.21483033"
 identifiers:
   - type: doi
     value: "10.5281/zenodo.21483033"


### PR DESCRIPTION
Follow-up to #22. That PR added the DOIs as `identifiers:`, but GitHub's **"Cite this repository"** widget (and its APA/BibTeX export) surfaces a top-level `doi:` most reliably — which is why the generated citation showed no DOI.

Adds top-level `doi: "10.5281/zenodo.21483033"` (the **concept** DOI — resolves to the latest version). The per-version DOIs remain in `identifiers:` for provenance.

agent_gate green.