### PR TITLE
docs: CT-11 requires a formalization lead, not a bare paper URL

### DIFF
--- a/docs/guide/contributor-tasks.md
+++ b/docs/guide/contributor-tasks.md
@@ -21,9 +21,13 @@ prior context, a single deterministic done-check. Take one, then climb.
 ### CT-11 — Add a candidate lead to an uncovered row (S) — **Pointer rung**
 
 - **Goal:** pick one `MAPPED`-only survey row in [`registry.yaml`](../../registry.yaml)
-  whose `candidate_formalizations` is `[]`, and add **one** lead — a repository
-  or paper URL that plausibly formalizes or proves it. No Lean, no proof, no
-  coverage claim.
+  whose `candidate_formalizations` is `[]`, and add **one** lead pointing at an
+  *existing* formalization. The entry needs all eight schema fields: a
+  `repository` URL, its immutable `revision`, the `framework`, the `declaration`
+  name, a `license`, an `inspection_state` (`UNVERIFIED` if you have only read the
+  source), a `relationship_review` (`PENDING` is fine), and `notes` — a bare paper
+  URL is not a candidate lead. A pen-and-paper result with no existing
+  formalization goes to **CT-14** instead. No Lean, no proof, no coverage claim.
 - **Acceptance:** a schema-valid `candidate_formalizations` entry;
   `scripts/setup.sh --pointer` (i.e. `scripts/agent_gate.sh`) green. A lead is
   candidate evidence, not coverage.


### PR DESCRIPTION
CT-11's goal said add "a repository **or paper** URL." But `candidate_formalizations` enforces all eight `CANDIDATE_LEAD_FIELDS` (`repository`, `revision`, `framework`, `license`, `declaration`, `inspection_state`, `relationship_review`, `notes`) and requires `repository` to be a valid http URL (`scripts/validate_registry.py:89`). A standalone paper URL cannot satisfy the schema, so `scripts/setup.sh --pointer` would reject it — CT-11's acceptance line contradicted its own goal.

This names the required fields in the goal and redirects a pen-and-paper result with no existing formalization to **CT-14** (the discovery-form rung). Issue #16 (the CT-11 first-task issue) is updated to match.

`agent_gate.sh` green (docs-path + registry views unaffected).