### PR TITLE
examples: add Fin 3 supervised NFL use-site

### DIFF
--- a/AISafetyAtlas/Examples/FirstContribution.lean
+++ b/AISafetyAtlas/Examples/FirstContribution.lean
@@ -47,6 +47,23 @@ example :
       aggregateOffTrainingLoss trainOn0 learnerConst1 :=
   no_free_lunch_supervised trainOn0 learnerConst0 learnerConst1
 
+/-- Constant-0 learner with a three-element label space. -/
+def learnerThreeConst0 : SupervisedLearner (Fin 2) (Fin 3) trainOn0 :=
+  fun _ _ => 0
+
+/-- Constant-2 learner with a three-element label space. -/
+def learnerThreeConst2 : SupervisedLearner (Fin 2) (Fin 3) trainOn0 :=
+  fun _ _ => 2
+
+/--
+The aggregate off-training-set loss remains learner-independent after enlarging
+the label space from `Fin 2` to `Fin 3`.
+-/
+example :
+    aggregateOffTrainingLoss trainOn0 learnerThreeConst0 =
+      aggregateOffTrainingLoss trainOn0 learnerThreeConst2 :=
+  no_free_lunch_supervised trainOn0 learnerThreeConst0 learnerThreeConst2
+
 /-
 YOUR TURN (CT-13, difficulty S)
 -------------------------------


### PR DESCRIPTION
## Summary

- add a second CT-13 use-site for `no_free_lunch_supervised`
- exercise the shipped theorem with a `Fin 3` label space rather than the starter's `Fin 2`
- keep the change confined to the non-public example layer

Closes #18.

## Unique value

The example shows that the supervised NFL facade is reusable when the label space is enlarged. It consumes the existing theorem directly and introduces no reproof or public declaration.

## Evidence and provenance

- theorem used: `AISafetyAtlas.Learning.no_free_lunch_supervised`
- import surface: `AISafetyAtlas.Learning`
- no external formalization, dependency, registry, or coverage change

## Public API and interpretation

No public Lean API change and no new AI-safety interpretation. This is an API use-site only.

## Validation

- [x] `lake build AISafetyAtlas.Examples.FirstContribution`
- [x] `./scripts/agent_gate.sh`
- [x] no `sorry`, `admit`, axioms, or unsafe declarations added
- [x] unrelated and local-only files excluded
