### PR TITLE
docs(CT-13): make the use-site append point unambiguous

### DIFF
--- a/AISafetyAtlas/Examples/FirstContribution.lean
+++ b/AISafetyAtlas/Examples/FirstContribution.lean
@@ -9,6 +9,10 @@ A minimal, self-contained file for your first Lean change (task **CT-13**,
 `docs/guide/contributor-tasks.md#open-now`). It compiles as-is, so you can copy
 it, add one line, and watch CI stay green.
 
+The first example below is the reference pattern; merged CT-13 contributions
+accumulate underneath it, so expect the list to grow. Append yours at the
+bottom, under the marker after the "YOUR TURN" block.
+
 Everything here is Foundation-free: it imports only `AISafetyAtlas.Learning`, so
 it builds under the fast `scripts/setup.sh --quick` path — no full Gödel build
 needed. The stable public facade is the single root import:
@@ -67,17 +71,26 @@ example :
 /-
 YOUR TURN (CT-13, difficulty S)
 -------------------------------
-Add ONE new `example` below that exercises an existing shipped theorem — no new
-math, just a use-site. Ideas:
+Add ONE new `example` of your own that exercises an existing shipped theorem —
+no new math, just a use-site. Ideas:
 
-  * a third constant learner and another `no_free_lunch_supervised` instance;
+  * another constant learner and another `no_free_lunch_supervised` instance;
   * a `no_free_lunch` instance over cost-sequence schedules
     (see `AISafetyAtlas.Examples.NFLConcrete` for the pattern);
   * anything from the README "Lean API" list, after switching to `import
     AISafetyAtlas`.
 
+APPEND IT AT THE BOTTOM, below this block and above the `end` line — not between
+the examples above. Those are earlier contributors' use-sites; leave them alone.
+The file is meant to accumulate, so a growing list here is the intended outcome,
+and appending keeps everyone's diffs from colliding.
+
 Then: `lake build AISafetyAtlas.Examples.FirstContribution` must be green and
-`python3 scripts/check_print_axioms.py` must stay clean. Open a pull request.
+`./scripts/agent_gate.sh` must stay clean. An anonymous `example` adds no public
+declaration, so you do not need to run the kernel axiom check locally — CI runs
+it over the headline surface for you. Open a pull request.
 -/
+
+-- ↓↓↓ APPEND YOUR CT-13 EXAMPLE HERE ↓↓↓
 
 end AISafetyAtlas.Examples.FirstContribution

--- a/docs/guide/contributor-tasks.md
+++ b/docs/guide/contributor-tasks.md
@@ -54,6 +54,9 @@ prior context, a single deterministic done-check. Take one, then climb.
   as your model and add one new `example` that exercises an existing shipped
   theorem (e.g. `no_free_lunch_supervised`, or anything on the README "Lean API"
   list over `import AISafetyAtlas`). No new math — a use-site, not a reproof.
+  **Append it at the bottom of that file**, under the marker after the "YOUR
+  TURN" block — not between the examples already there. The file is meant to
+  accumulate use-sites, and appending keeps contributors' diffs from colliding.
 - **Acceptance:** `lake build AISafetyAtlas.Examples.FirstContribution` (or
   `.PublicAPI`) green and `scripts/agent_gate.sh` clean. A non-public `example`
   needs no local axiom audit — CI runs `check_print_axioms.py` over the headline


### PR DESCRIPTION
Follow-up to #26.

## Summary

- name the append point in `AISafetyAtlas/Examples/FirstContribution.lean` instead of implying one
- record that the file is meant to accumulate CT-13 use-sites
- align the starter's validation line with CT-13's stated acceptance

## Why

#26 inserted its example between the starter's first example and the "YOUR TURN" block, leaving the instruction "add ONE new `example` below" pointing at a file that already holds two. The block was already last before `end`, so the ambiguity was in the wording, not the layout.

## Changes

- **header docstring:** the first example is the reference pattern; merged use-sites accumulate underneath it, so a growing list is the intended outcome
- **YOUR TURN block:** append at the bottom, above `end`, not between the existing examples; explicit `-- ↓↓↓ APPEND YOUR CT-13 EXAMPLE HERE ↓↓↓` marker gives one obvious insertion point
- **YOUR TURN block:** validation line now points at `./scripts/agent_gate.sh` rather than `python3 scripts/check_print_axioms.py`. CT-13's acceptance criteria already say a non-public `example` needs no local axiom audit, so the starter contradicted the task
- **`docs/guide/contributor-tasks.md` CT-13:** same append instruction beside the goal

## Public API and interpretation

No Lean statement, public declaration, or AI-safety interpretation changes. Comments and docs only.

## Validation

- [x] `lake build AISafetyAtlas.Examples.FirstContribution` — green, 1007 jobs
- [x] `./scripts/agent_gate.sh` — clean
- [x] no `sorry`, `admit`, axioms, or unsafe declarations