### PR TITLE
test: add Fin 3 no-free-lunch use site

### DIFF
--- a/AISafetyAtlas/Examples/FirstContribution.lean
+++ b/AISafetyAtlas/Examples/FirstContribution.lean
@@ -93,4 +93,27 @@ it over the headline surface for you. Open a pull request.
 
 -- ↓↓↓ APPEND YOUR CT-13 EXAMPLE HERE ↓↓↓
 
+/-- Sample the first point of `Fin 3`. -/
+def scheduleFin3First : NonadaptiveSchedule (Fin 3) 1 where
+  sample := fun _ => 0
+  injective := by
+    intro a b _
+    exact Subsingleton.elim a b
+
+/-- Sample the last point of `Fin 3`. -/
+def scheduleFin3Last : NonadaptiveSchedule (Fin 3) 1 where
+  sample := fun _ => 2
+  injective := by
+    intro a b _
+    exact Subsingleton.elim a b
+
+/--
+Any cost-sequence score has equal aggregate performance on the first-point and
+last-point length-one schedules over `Fin 3`.
+-/
+example (Φ : CostPerformance 1 (Fin 2)) :
+    aggregatePerformance Φ scheduleFin3First =
+      aggregatePerformance Φ scheduleFin3Last :=
+  no_free_lunch Φ scheduleFin3First scheduleFin3Last
+
 end AISafetyAtlas.Examples.FirstContribution


### PR DESCRIPTION
## Summary

Adds a distinct CT-13 use-site for `AISafetyAtlas.Learning.no_free_lunch` over two concrete length-one schedules on `Fin 3`.

Addresses #28.

## Unique value

The example demonstrates that an arbitrary cost-sequence score has equal aggregate performance when the schedule samples either the first or last point of `Fin 3`. It reuses the shipped theorem and adds no new mathematical result.

## Evidence and provenance

- Existing maintained formalization: `AISafetyAtlas.Learning.no_free_lunch`
- Dependencies: unchanged
- Validation: `scripts/setup.sh` (full), `scripts/agent_gate.sh`, and `python3 scripts/check_print_axioms.py`
- Axiom audit: 22 declarations within `{propext, Classical.choice, Quot.sound}`

## Public API and interpretation

No public Lean API, registry, coverage, dependency, or AI-safety interpretation changes. The contribution is confined to `AISafetyAtlas/Examples/FirstContribution.lean`.

## Checklist

- [x] I checked for an existing maintained formalization before adding a proof.
- [x] Coverage claims and generated status files are unchanged.
- [x] No adapted external work or new dependency is introduced.
- [x] The full Lean build and explicit targets pass without incomplete proofs.
- [x] The registry and current-state validators pass.
- [x] I kept unrelated and local-only files out of this pull request.