### PR TITLE
docs(CT-13): cap the use-site rung at one per contributor

### DIFF
--- a/AISafetyAtlas/Examples/FirstContribution.lean
+++ b/AISafetyAtlas/Examples/FirstContribution.lean
@@ -80,10 +80,18 @@ no new math, just a use-site. Ideas:
   * anything from the README "Lean API" list, after switching to `import
     AISafetyAtlas`.
 
+This is an onboarding exercise, ONE PER CONTRIBUTOR — it proves you can drive
+the toolchain, not that the API needed another caller. Coverage here is already
+complete: `AISafetyAtlas.Examples.PublicAPI` applies every declaration on the
+README "Lean API" list, and `NFLConcrete` covers the learning-layer schedules.
+So a second CT-13 will be closed, and widening a type parameter (`Fin 2` →
+`Fin 3`) or changing a constant in an already-exercised theorem is not a
+distinct use-site. Once yours has merged, take a rung that moves coverage —
+`docs/guide/contributor-tasks.md`, "Open now".
+
 APPEND IT AT THE BOTTOM, below this block and above the `end` line — not between
 the examples above. Those are earlier contributors' use-sites; leave them alone.
-The file is meant to accumulate, so a growing list here is the intended outcome,
-and appending keeps everyone's diffs from colliding.
+Appending keeps everyone's diffs from colliding.
 
 Then: `lake build AISafetyAtlas.Examples.FirstContribution` must be green and
 `./scripts/agent_gate.sh` must stay clean. An anonymous `example` adds no public

--- a/docs/guide/contributor-tasks.md
+++ b/docs/guide/contributor-tasks.md
@@ -48,21 +48,39 @@ prior context, a single deterministic done-check. Take one, then climb.
   verification is a first-class contribution.
 - **Does not change:** any Lean, any relationship classification.
 
-### CT-13 — Add one Lean use-site over a shipped theorem (S) — **API use-site rung**
+### CT-13 — Add one Lean use-site over a shipped theorem (S) — **Onboarding exercise**
+
+**This is a toolchain exercise, not coverage work — one per contributor.** The
+public API is already fully exercised:
+[`AISafetyAtlas/Examples/PublicAPI.lean`](../../AISafetyAtlas/Examples/PublicAPI.lean)
+carries an applied use-site for every declaration on the README "Lean API" list,
+and [`NFLConcrete.lean`](../../AISafetyAtlas/Examples/NFLConcrete.lean) covers
+the learning-layer schedules. A new `example` adds no coverage, closes no gap,
+and changes no status file. What it does is prove you can drive the toolchain —
+fork, branch, `lake build`, `agent_gate.sh`, PR — before you take on work where
+a mistake is expensive. That is the whole point, and it is worth one PR.
 
 - **Goal:** copy [`AISafetyAtlas/Examples/FirstContribution.lean`](../../AISafetyAtlas/Examples/FirstContribution.lean)
   as your model and add one new `example` that exercises an existing shipped
   theorem (e.g. `no_free_lunch_supervised`, or anything on the README "Lean API"
   list over `import AISafetyAtlas`). No new math — a use-site, not a reproof.
   **Append it at the bottom of that file**, under the marker after the "YOUR
-  TURN" block — not between the examples already there. The file is meant to
-  accumulate use-sites, and appending keeps contributors' diffs from colliding.
+  TURN" block — not between the examples already there. Appending keeps
+  contributors' diffs from colliding.
 - **Acceptance:** `lake build AISafetyAtlas.Examples.FirstContribution` (or
   `.PublicAPI`) green and `scripts/agent_gate.sh` clean. A non-public `example`
   needs no local axiom audit — CI runs `check_print_axioms.py` over the headline
   surface for you; reserve that check for new *public* theorems and bridges.
   Runs under the fast `scripts/setup.sh --quick` path if you stay on the learning
   layer.
+- **Terminal rung — do not repeat it.** Once your CT-13 has merged, a second one
+  will be closed. Varying a type parameter (`Fin 2` → `Fin 3`) or a constant in
+  an already-exercised theorem is not a distinct use-site.
+- **Next:** CT-11, CT-12, or CT-14 if you want another single-sitting unit; the
+  open `Formalize BY-0xx` issues or CT-6 / CT-8 / CT-9 / CT-15 for work that
+  moves coverage. If you are running an AI coding agent, prefer the Lean rungs:
+  `lake build` checks the result, so a wrong answer costs a red CI run rather
+  than a maintainer audit.
 - **Does not change:** any theorem statement or the public facade.
 
 ### CT-14 — Report a proof we don't have (S) — **Pointer rung**


### PR DESCRIPTION
## Summary

CT-13 had no exit condition, and `FirstContribution.lean` actively invited repetition ("The file is meant to accumulate, so a growing list here is the intended outcome"). Two merged/open PRs (#26, #29) walked the file's own ideas list in order and added use-sites for theorems that were already exercised elsewhere.

The coverage those examples were nominally adding is already complete. `Examples/PublicAPI.lean` applies every declaration on the README "Lean API" list in proof position — 19 declarations, no `#check` filler — and `Examples/NFLConcrete.lean` covers the learning-layer schedules, including the length-one `Fin`-schedule pattern that #29 re-derives over `Fin 3`.

This relabels CT-13 as what it actually is: an onboarding exercise that proves a contributor can drive the toolchain, one per contributor, terminal.

## Unique value

None — this is a documentation correction. It removes an instruction that was generating duplicate work and states the rule the task always needed:

- CT-13 retitled **Onboarding exercise**; `PublicAPI.lean` and `NFLConcrete.lean` named as the existing coverage record, with a note to read them first.
- Terminal-rung bullet: a second CT-13 will be closed, and widening a type parameter (`Fin 2` → `Fin 3`) or changing a constant in an already-exercised theorem is not a distinct use-site.
- Next-rung pointer to CT-11/12/14 and the coverage rungs.
- Guidance for agent-run contributions: prefer the Lean rungs, where `lake build` and `agent_gate.sh` check the result, over pointer and citation tasks whose output no tool can verify.
- `FirstContribution.lean`: the "meant to accumulate" line is gone; the YOUR TURN block now carries the one-per-contributor rule. Block-comment content only.

Issue #28 has been updated to match.

## Evidence and provenance

- `scripts/agent_gate.sh` green: registry ok (44 results, 67 sources, 17 formalizations, 23 Lean artifacts), landscape ok (10 entries), generated views unchanged, current state ok, 186 relative links across 30 files resolve.
- The CT-13 heading changed, so its anchor changed. No in-repo reference used the old anchor; #28's body links to the new one.
- `FirstContribution.lean` edit is confined to the `/-` … `-/` block opening at line 71 and closing at line 100. No comment delimiters introduced, no declaration touched.
- Saturation claim verified by grep: all 13 declarations listed under "Public Lean API" in `AGENTS.md` appear in applied position in `Examples/PublicAPI.lean`.

## Public API and interpretation

No public Lean API change, no theorem statement change, no registry or landscape change, no coverage claim, no AI-safety interpretation. Documentation and one Lean block comment.

## Checklist

- [x] I checked for an existing maintained formalization before adding a proof. (No proof added; the change documents that the existing ones already cover the task.)
- [x] I updated registry and status evidence where coverage claims changed. (No coverage claim changed.)
- [x] I recorded attribution, immutable versions, and licenses for adapted work. (No adapted work.)
- [ ] `lake build` passes without incomplete proofs. — not run locally (no `.lake` cache present); the change is block-comment-only and CI's Lean job covers it.
- [x] `python3 scripts/validate_registry.py` passes. (Via `agent_gate.sh`.)
- [ ] `python3 scripts/audit_release.py` passes. — not run; no release, version, or coverage surface touched.
- [x] I kept unrelated and local-only files out of this pull request.
