### PR TITLE
Say on main that v0.7.0 is published, and make the gate require it

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -1,7 +1,7 @@
 # Project State
 
 Updated: 2026-08-15
-Current phase: `v0.7.0` is **prepared and not yet published** — see
+Current phase: `v0.7.0` is **published** — see
 [`docs/releases/v0.7.md`](docs/releases/v0.7.md). It is a depth release on
 Wolpert's *Physical limits of inference*, carried at the source's own
 quantifiers with the finiteness restrictions the proofs never used removed and
@@ -64,7 +64,8 @@ stale without anyone noticing.
   increment, then the workbench-model and process release), and
   [v0.5.1](docs/releases/v0.5.1.md) (conjecture-ledger maintenance), and
   [v0.6](docs/releases/v0.6.md) (knowability kernel, Breuer core, BY-044,
-  public page).
+  public page), and [v0.7](docs/releases/v0.7.md) (Wolpert at print scope, the
+  probability substrate, the first domain joint, and a runnable kernel).
 - **Reproduction, triage and search evidence** — [`docs/provenance/`](docs/provenance/),
   including the durable residual-gap record
   [`a1-a3-b1-b3-b7-reverification.md`](docs/provenance/a1-a3-b1-b3-b7-reverification.md)
@@ -153,9 +154,11 @@ stale without anyone noticing.
 
   Evidence: [self-measurement kernel](docs/provenance/self-measurement-kernel.md),
   [landscape sweep](docs/provenance/embedded-self-knowledge-landscape.md).
-- `information-limits-foundation` is unmerged local work and is **not** published.
-  It carries the Wolpert 2008/2018 development and, on top of it, the first
-  things that make that development usable rather than only correct:
+- v0.7.0 is published. `information-limits-foundation` carried it and was
+  squashed into `main` as `1270117`; pre-squash history is kept locally on
+  `archive/information-limits-foundation-pre-squash-20260815`. It carries the
+  Wolpert 2008/2018 development and, on top of it, the first things that make
+  that development usable rather than only correct:
 
   **The spine–device joint.** `LAND-KNOW-DEVICE-001` states the conditional
   transports between `LAND-KNOW-001`'s `Knowable` and BY-024's `WeaklyInfers`.

--- a/docs/releases/v0.7.md
+++ b/docs/releases/v0.7.md
@@ -1,9 +1,9 @@
 # v0.7 Release
 
 - Prepared: 2026-08-15
-- Published: _pending_ — to `main`; tag `v0.7.0`
-- Publication status: **prepared** — this note describes the intended `v0.7.0`
-  tag. The tag, once cut, is the canonical publication record.
+- Published: 2026-08-15 to `main`; tag `v0.7.0`
+- Publication status: **published** — the `v0.7.0` tag is the canonical
+  publication record.
 
 Package version: **0.7.0** (`lakefile.toml`, `CITATION.cff`).
 
@@ -168,5 +168,5 @@ These are inventory and evidence counts, not a completion target.
 ## Citation and publication boundary
 
 The published set is the repository's git tags and GitHub Releases. This note
-describes what the `v0.7.0` tag is intended to contain; that tag, not this file,
-is the canonical record.
+describes what the `v0.7.0` tag contains; that tag, not this file, is the
+canonical record.

--- a/scripts/validate_current_state.py
+++ b/scripts/validate_current_state.py
@@ -459,16 +459,27 @@ def main() -> None:
     # package version carries a patch component (for example 0.4.0). Match on
     # the series.
     minor_series = ".".join(lake_version.split(".")[:2])
+    release_note = ROOT / f"docs/releases/v{minor_series}.md"
     require(
-        (ROOT / f"docs/releases/v{minor_series}.md").is_file(),
+        release_note.is_file(),
         f"missing release note docs/releases/v{minor_series}.md "
         f"for package version {lake_version}",
+    )
+    # The publication line belongs to the release PR, not to a follow-up commit:
+    # v0.5.1 and v0.6 both carry theirs in their own squash, and their tags sit
+    # on it. A `_pending_` placeholder that reaches `main` makes the tagged tree
+    # say the tag does not exist, so it fails here rather than in review.
+    require(
+        "_pending_" not in release_note.read_text(encoding="utf-8"),
+        f"docs/releases/v{minor_series}.md still has a `_pending_` placeholder "
+        f"while the package version is {lake_version}. Fill in the publication "
+        "line in the release pull request itself; the tag goes on that commit.",
     )
     print(
         "current state ok: required public files, Apache-2.0, disclaimer, "
         "complete Lean build closure, executable reproduction scripts, "
         "STATE snapshot + release-status markers, version/release coherence, "
-        "and strict-trust Lean sources"
+        "no pending publication placeholder, and strict-trust Lean sources"
     )
 
 


### PR DESCRIPTION
The release note shipped with `Published: _pending_` and STATE.md with
"prepared and not yet published", because the flip was treated as a post-merge
step. It is not one here: v0.5.1 and v0.6 both carry their publication line
inside their own release PR, and their tags sit on that squash commit. This
restores that, in v0.6's format — date and tag, no SHA, since the tag is the
canonical record. STATE.md also gains v0.7 in the release list, and its branch
paragraph now says `information-limits-foundation` was squashed into main
rather than that it is unmerged local work.

The reason this needed a second commit at all is that nothing checked it.
`validate_current_state.py` verified the release note *exists* for the package
version and stopped there, so a `_pending_` placeholder passed every gate and
reached `main`, where it made the tagged tree deny its own tag. It now fails,
naming the convention in the error. Verified both ways: with the placeholder
restored the validator exits 1, and exits 0 once filled.

Not automated in `scripts/test_validators.py`: that harness copies JSON ledgers
and mutates fields, so covering a Markdown release note needs it to carry
`docs/releases/` and `lakefile.toml` too. Worth doing, not done here.