### PR TITLE
The contributor skill that was designed and never written

### DIFF
--- a/.agents/skills/atlas-contribution/SKILL.md
+++ b/.agents/skills/atlas-contribution/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: atlas-contribution
+description: 'Land a change in the AI Safety Formalization Atlas so it satisfies the repository''s rules without the contributor having to learn them. Use this whenever the work is a contribution to this repository — adding or editing a Lean theorem, definition or example, a registry or conjecture row, provenance, documentation, or tooling — and whenever the request is "how do I contribute", "add this to the atlas", "is this ready to submit", "open a PR", or "what do I still owe". It routes rather than instructs: three commands decide what applies to this particular change, and the rules stay in AGENTS.md where they are enforced.'
+---
+
+# Contributing to the atlas
+
+You write the mathematics. This walks the procedure.
+
+**This file contains no rules.** They live in `AGENTS.md` and `CONTRIBUTING.md`,
+and a second copy would drift from them silently. What is here is the order to
+do things in and which command answers which question.
+
+## The three commands
+
+```console
+python3 scripts/preflight.py     # what does THIS change oblige?
+./scripts/agent_gate.sh          # is it mechanically correct?
+python3 scripts/preflight.py --brief    # the cheap re-read on a retry
+```
+
+`preflight.py` reads the diff, decides which of six contribution kinds it
+contains — Lean library · example or witness · ledger · generated file · docs ·
+tooling — and prints only the governing sections, **sliced verbatim out of
+`AGENTS.md` and `CONTRIBUTING.md` at runtime**. What you read is what binds. Run
+it with nothing changed and it tells you where to find an unclaimed target
+instead.
+
+## The order
+
+1. **Write the theorem, definition or row.** This is the part that is yours.
+2. **`python3 scripts/preflight.py`** — it names the obligations and the
+   commands for what you actually touched, and nothing else.
+3. **Do what it names.** Every kind has a build or regeneration step; generated
+   files are regenerated, never hand-edited.
+4. **`./scripts/agent_gate.sh`** — the verdict. `--fast` is the retry loop after
+   it has failed once; the full gate is owed before the commit either way.
+5. **Open the PR**, and answer in its body the one question no gate can:
+   *what does your statement say, what does the source say, and where do they
+   differ?* A reviewer needs a claim they can disagree with, not silence.
+
+## What decides, and what only advises
+
+`agent_gate.sh` decides. `preflight.py` advises and always exits 0 — it is a
+briefing, not a gate. Two of the checks inside the gate are advisory too and say
+so in their output: a changed graded statement and an unwitnessed scope claim are
+**questions**, not verdicts. Answer them in the change that raises them.
+
+## What no script can do for you
+
+Whether a Lean statement says what its source says. Whether a witness inhabits
+the hypotheses or merely compiles. Whether a second formalization earns its
+place. These are why the repository has human review, and they are where a PR
+is actually accepted or rejected — so put your reasoning in the PR body rather
+than leaving it to be reconstructed.
+
+## If a statement looks wrong
+
+Say so and stop. A `sorry` with a note naming the suspected defect is a better
+outcome than a proof of something else. An agent that may edit statements can
+always close a goal by editing the goal, and every gate stays green when it does.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,10 @@ apply, each naming the section here that governs it. It restates no rule and
 decides nothing — the gate does that — but it removes the step where a
 contributor reads a thousand lines of policy to find the twenty that bind them.
 
+Agents that load project skills will find the same route as
+[`.agents/skills/atlas-contribution/SKILL.md`](.agents/skills/atlas-contribution/SKILL.md);
+it holds the order to work in and no rules, which stay here.
+
 Open this file, `STATE.md`, and `docs/agent/INDEX.md` first. The other paths
 below are conditional and should be opened only when the task needs them.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,10 @@ Detail on grades: [methodology](docs/guide/methodology.md).
 
 ## Before you open a pull request
 
+Working with an AI agent? Point it at
+[`.agents/skills/atlas-contribution/SKILL.md`](.agents/skills/atlas-contribution/SKILL.md),
+which is the same three commands in the order to run them.
+
 Run `python3 scripts/preflight.py`. It looks at what you changed and prints the
 obligations a reviewer will check, with the section of `AGENTS.md` or this file
 that governs each — so you see the rules for your change rather than all of

--- a/scripts/preflight.py
+++ b/scripts/preflight.py
@@ -173,7 +173,17 @@ def changed_paths(base: str, staged: bool) -> list[str]:
         ref = merge_base.stdout.strip() or base
         cmd = ["git", "diff", "--name-only", ref]
     result = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
-    return [p for p in result.stdout.split("\n") if p.strip()]
+    paths = [p for p in result.stdout.split("\n") if p.strip()]
+    if not staged:
+        # A first contribution is usually a *new* file, and `git diff` does not
+        # see one until it is added. Leaving them out made this report silent on
+        # precisely the case it exists for.
+        untracked = subprocess.run(
+            ["git", "ls-files", "--others", "--exclude-standard"],
+            cwd=ROOT, capture_output=True, text=True,
+        )
+        paths += [p for p in untracked.stdout.split("\n") if p.strip()]
+    return sorted(set(paths))
 
 
 def main() -> int:


### PR DESCRIPTION
`scripts/preflight.py` shipped, and the routing from `AGENTS.md` and `CONTRIBUTING.md` shipped, but the thin driver that ties them together did not. It was designed, then dropped when attention moved to the gate's runtime, and nothing said so. This is that file.

## What is here

`.agents/skills/atlas-contribution/SKILL.md` is 61 lines and **contains no rules**. That is the whole design. The rules live in `AGENTS.md` where they are enforced, `preflight.py` slices the governing sections out of that file at runtime, and a second copy here would drift from both without anything noticing. What the skill carries is the order to work in, which command answers which question, and the boundary: `agent_gate.sh` decides, `preflight.py` advises, and statement fidelity is decided by a human reading the source.

`.agents/` is the cross-client location and is not gitignored here, so the file is committable and reachable by any agent that scans for project skills. `AGENTS.md` and `CONTRIBUTING.md` each gain four lines pointing at it — one aimed at agents, one at people working with one.

## Two defects the work found in itself

**`preflight.py` was blind to new files.** Writing the skill meant creating one, and the report showed two changed paths for a three-file change: `git diff` does not see untracked files. A first contribution is usually a new file, which is precisely the case the tool exists for. It now unions in `git ls-files --others --exclude-standard`.

**The skill's YAML frontmatter did not parse.** A plain YAML scalar cannot contain `": "`, the description contains it, and any loader that parses frontmatter rather than grepping it gets no `name` and no `description` — the file would have shipped invisible to exactly the clients it was written for. Now a single-quoted scalar, verified by round-tripping `yaml.safe_load` against the original text so no wording moved.

The lesson is not the quoting. Authoring a skill has a validator and none was run, in a repository whose argument is that unvalidated work reads exactly like validated work.

## Checks

- `./scripts/agent_gate.sh` full: green, 21.6s, 109 pytest, `ty` clean.
- Publication sweep, tree and history: 426 files, 421 Markdown links resolving, 0 hard findings, 0 churn.

## What a reviewer should push back on

Whether a routing file that restates nothing is worth a file at all, given `AGENTS.md` already routes. The argument for it is that `.agents/skills/` is scanned automatically by clients that would otherwise read nothing; the argument against is that it is a third place to look.