### PR TITLE
fix: harden migration validation portability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
           # Keep pytest, ty, and the interpreter used by agent_gate in one
           # environment.  Installing with a different pip than the executable
           # used by ty can make CI report a false unresolved-import failure.
+          echo "VIRTUAL_ENV=$ci_venv" >> "$GITHUB_ENV"
           echo "$ci_venv/bin" >> "$GITHUB_PATH"
       - name: Cheap agent gate
         run: ./scripts/agent_gate.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# macOS Finder metadata.
+.DS_Store
+
 # Lean/Lake build artifacts.
 /.lake/
 # The public page in /site is a static file deployed as-is; nothing to ignore.

--- a/scripts/agent_gate.sh
+++ b/scripts/agent_gate.sh
@@ -19,9 +19,14 @@ done
 if [ "$quiet" = 1 ]; then
   gate_log="$(mktemp)"
   trap 'rm -f "$gate_log"' EXIT
-  inner=()
-  [ "$lean_only" = 1 ] && inner=(--fast)
-  if "$0" "${inner[@]}" >"$gate_log" 2>&1; then
+  # Under Bash 3.2 with `set -u`, expanding an empty array is an
+  # unbound-variable error. Keep the recursive command nonempty instead.
+  if [ "$lean_only" = 1 ]; then
+    quiet_command=("$0" --fast)
+  else
+    quiet_command=("$0")
+  fi
+  if "${quiet_command[@]}" >"$gate_log" 2>&1; then
     if [ "$lean_only" = 1 ]; then
       echo "agent_gate: ok (quiet, --fast; Python self-tests NOT run)"
     else

--- a/scripts/validate_registry.py
+++ b/scripts/validate_registry.py
@@ -121,15 +121,35 @@ def valid_http_url(value: object) -> bool:
 LEAN_MODULE_SHAPE = re.compile(r"^[A-Z][A-Za-z0-9_']*(?:\.[A-Z][A-Za-z0-9_']*)+$")
 
 
+def exact_file(root: Path, relative: Path) -> bool:
+    """Whether ``relative`` is a file below ``root`` with exact path spelling.
+
+    Lean module names are case-sensitive even when a contributor's filesystem is
+    not.  ``Path.is_file()`` alone treats ``Aisafetyatlas`` as
+    ``AISafetyAtlas`` on default macOS volumes, turning a broken build target
+    into a passing validator result.
+    """
+    current = root
+    for component in relative.parts:
+        try:
+            names = {entry.name for entry in current.iterdir()}
+        except OSError:
+            return False
+        if component not in names:
+            return False
+        current /= component
+    return current.is_file()
+
+
 def lean_module_exists(module: str) -> bool:
     """Whether a dotted module name resolves, in this tree or a Lake package."""
-    rel = module.replace(".", "/") + ".lean"
-    if (ROOT / rel).is_file():
+    rel = Path(module.replace(".", "/") + ".lean")
+    if exact_file(ROOT, rel):
         return True
     packages = ROOT / ".lake" / "packages"
     if packages.is_dir():
         for package in packages.iterdir():
-            if (package / rel).is_file():
+            if exact_file(package, rel):
                 return True
     return False
 

--- a/tests/test_agent_gate_compat.py
+++ b/tests/test_agent_gate_compat.py
@@ -1,0 +1,54 @@
+"""Compatibility smoke test for the quiet agent-gate path.
+
+The quiet wrapper invokes the gate recursively.  Bash 3.2, still shipped by
+macOS, treats an empty array expansion under ``set -u`` as an unbound variable,
+so this must exercise the actual recursive call rather than merely parse it.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+BASH = Path("/bin/bash")
+
+
+def _stub(path: Path) -> None:
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+@pytest.mark.skipif(not BASH.is_file(), reason="agent_gate.sh requires Bash")
+def test_quiet_mode_runs_under_nounset(tmp_path: Path) -> None:
+    """A minimal fake checkout reaches the wrapper without running real gates."""
+    root = tmp_path / "atlas"
+    scripts = root / "scripts"
+    scripts.mkdir(parents=True)
+    gate = scripts / "agent_gate.sh"
+    shutil.copy2(ROOT / "scripts" / "agent_gate.sh", gate)
+
+    stub_bin = tmp_path / "bin"
+    stub_bin.mkdir()
+    for name in ("python3", "git", "ty", "pytest"):
+        _stub(stub_bin / name)
+
+    environment = dict(os.environ)
+    environment["PATH"] = f"{stub_bin}{os.pathsep}{environment['PATH']}"
+    result = subprocess.run(
+        [str(BASH), str(gate), "--quiet"],
+        cwd=root,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "agent_gate: ok (quiet; full checks passed)" in result.stdout

--- a/tests/test_coverage_audit_checks.py
+++ b/tests/test_coverage_audit_checks.py
@@ -132,6 +132,7 @@ def test_lean_module_shape_accepts_module_paths_and_rejects_prose():
     "Mathlib.Totally.Fictional",
     "AISafetyAtlas.Control.NoSuchModule",
     "Aisafetyatlas.Control.RequisiteVariety",
+    "AISafetyAtlas.Control.requisiteVariety",
 ])
 def test_nonexistent_modules_do_not_resolve(module):
     assert not registry.lean_module_exists(module)


### PR DESCRIPTION
## Why

Make the Lean 4.33 migration validation behave consistently on macOS and Linux CI, and prevent macOS Finder metadata from entering future diffs.

## Scope

- Activate the CI virtual environment explicitly so `ty` resolves the dependencies installed for `agent_gate`.
- Make `agent_gate.sh --quiet` compatible with macOS Bash 3.2 under `set -u`.
- Require exact filesystem case when validating Lean build targets.
- Ignore `.DS_Store` at any path.
- Checked existing formalizations and dependencies: no Lean source, Lake manifest/toolchain, registry, generated-view, or public-API changes.
- Domain interpretation: none; this is validator and repository-hygiene work only.

## Evidence

- On default macOS volumes, `Path.is_file()` accepted wrongly cased module paths; the validator now checks each actual directory entry.
- Bash 3.2 raises an unbound-variable error for the former empty-array expansion under `set -u`; the quiet recursion is now always nonempty.

## Safety and compatibility

The changes preserve the existing gate commands. Linux CI continues to use the same virtual environment it installs; macOS now follows Lean case sensitivity and can run quiet mode. The `.DS_Store` pattern ignores Finder metadata only, including nested copies.

## Validation

- `git check-ignore -v docs/.DS_Store` and nested-path checks
- `git diff --check`
- `./scripts/agent_gate.sh --quiet`
- `python -m pytest tests/test_agent_gate_compat.py tests/test_coverage_audit_checks.py -q` (27 passed)
- `ty check scripts tests`

## Not done

No Lean theorem, proof, source evidence, dependency, package-version, registry, generated-artifact, external-service, or deployment change.