### PR TITLE
Say which Python the validators need, and check it before they run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ __pycache__/
 # `python3 scripts/render_coverage_artifact.py`. It had no reader in the tree
 # and cost 218 KB tracked.
 /docs/status/coverage-audit.html
+
+# Local interpreter for the validators, e.g. `python3 -m venv .venv` or
+# `uv venv --python 3.13 .venv`. The repository pins no Python of its own.
+/.venv/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -476,7 +476,10 @@ Cheap preflight:
 The gate ends with `pytest tests/` (malformed-shape regressions) and
 `ty check scripts/ tests/`. Both are skipped with a notice when the tool is not
 installed, so the gate still runs without them; CI installs both, so neither is
-optional on a pull request. Install with `python3 -m pip install pytest ty`.
+optional on a pull request. `check_conjecture_grade_prose` needs PyYAML and is
+skipped the same way. Install all three with
+`python3 -m pip install pytest ty pyyaml`. Everything else in the gate is the
+standard library of Python 3.9 or newer, which the gate checks before it starts.
 
 ### The `--fast` lane (`--lean` is the old name)
 

--- a/README.md
+++ b/README.md
@@ -446,7 +446,10 @@ Nothing here needs the whole picture: take the row that matches what you
 have and ignore the rest.
 <!-- END GENERATED ROUTING -->
 
-No toolchain needed for the first row — the validators are pure-stdlib Python 3:
+No toolchain needed for the first row — the validators need only Python 3.9 or
+newer and its standard library. One check reads a ledger through PyYAML and is
+skipped with a notice if that is absent; `pytest` and `ty` are likewise optional
+locally. CI installs all three, so none of them is optional on a pull request:
 
 ```console
 scripts/setup.sh --pointer   # cheap validators only; no Lean toolchain

--- a/scripts/agent_gate.sh
+++ b/scripts/agent_gate.sh
@@ -58,6 +58,16 @@ fi
 # measure, do not inherit a number.
 # Everything that reads the tree, the ledgers, or the generated views still
 # runs.  See AGENTS.md "Validation" for when the full gate is mandatory.
+
+# Ten call sites across six scripts use str.removesuffix / str.removeprefix and
+# functools.cache, all of which are Python 3.9. Checked once, here, because the
+# failure it replaces was an AttributeError raised from inside whichever
+# validator happened to run first -- which reads as a bug in that validator.
+if ! python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3, 9) else 1)'; then
+  echo "error: the validators need Python 3.9 or newer; python3 is $(python3 -V 2>&1)" >&2
+  exit 1
+fi
+
 skip_self_tests() { [ "$lean_only" = 1 ]; }
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -168,8 +178,18 @@ python3 scripts/generate_non_claims.py --check
 echo "==> check_docstring_identifiers"
 python3 scripts/check_docstring_identifiers.py
 
-echo "==> check_conjecture_grade_prose"
-python3 scripts/check_conjecture_grade_prose.py
+# check_conjecture_grade_prose is the one gate script that reads a ledger through
+# the real YAML parser rather than the hand-rolled one, so PyYAML is a genuine
+# dependency of this step and of no other. Skipped with a notice like pytest and
+# ty below, rather than crashing with a traceback: a contributor who was told the
+# validators need no install should not meet a ModuleNotFoundError here.
+if python3 -c "import yaml" >/dev/null 2>&1; then
+  echo "==> check_conjecture_grade_prose"
+  python3 scripts/check_conjecture_grade_prose.py
+else
+  echo "==> check_conjecture_grade_prose"
+  echo "PyYAML not installed; skipping conjecture prose check (CI runs it)"
+fi
 
 echo "==> check_cited_declarations"
 python3 scripts/check_cited_declarations.py

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -33,7 +33,16 @@ require() {  # require <cmd> <why>
   fi
 }
 
-require python3 "the validators are pure-stdlib Python 3."
+require python3 "the validators are Python 3.9+ and its standard library."
+
+# The floor is real: str.removesuffix, str.removeprefix and functools.cache are
+# 3.9, and ten call sites across six validators use them. Ubuntu 20.04 still
+# ships 3.8 as python3, so this fires on a live platform rather than a
+# hypothetical one, and it is worth a sentence rather than an AttributeError.
+if ! python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3, 9) else 1)'; then
+  echo "error: the validators need Python 3.9 or newer; python3 is $(python3 -V 2>&1)" >&2
+  exit 1
+fi
 
 if [ "$MODE" = "pointer" ]; then
   echo "==> pointer mode: skipping the Lean toolchain"

--- a/tests/test_conjecture_grade_prose.py
+++ b/tests/test_conjecture_grade_prose.py
@@ -23,6 +23,18 @@ import importlib.util
 import sys
 from pathlib import Path
 
+import pytest
+
+# The checker itself imports PyYAML, and `_load` executes it, so an absent
+# parser fails *collection* -- which interrupts the whole suite, not just this
+# module. agent_gate.sh skips the standalone check for the same reason; without
+# this the skip is illusory, because the gate's pytest step would still stop
+# here.
+pytest.importorskip(
+    "yaml",
+    reason="check_conjecture_grade_prose reads conjectures.yaml through PyYAML",
+)
+
 ROOT = Path(__file__).resolve().parent.parent
 SCRIPTS = ROOT / "scripts"
 

--- a/tests/test_python_floor.py
+++ b/tests/test_python_floor.py
@@ -1,0 +1,183 @@
+"""The validators claim a Python floor; this checks the claim both ways.
+
+The floor was not chosen, it was measured: ``str.removesuffix``,
+``str.removeprefix`` and ``functools.cache`` are all 3.9, and ten call sites
+across six validators use them.  Nothing in ``scripts/`` or ``tests/`` needs
+3.10 or later, so 3.9 is the real requirement rather than a convenient one.
+
+Two failures are possible and both matter.  A script that reaches for a newer
+feature silently raises the floor, and on Ubuntu 20.04 -- whose ``python3`` is
+still 3.8 -- that surfaces as an ``AttributeError`` from inside whichever
+validator happened to run first, which reads as a bug in that validator.  A
+document or bootstrap script that names a different floor from the one the code
+needs sends a contributor to the same place by a longer route.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+FLOOR = (3, 9)
+
+# Syntax is left to the parser: ast.parse(..., feature_version=FLOOR) rejects
+# match statements, except*, PEP 695 type aliases and generic parameter lists
+# with the version that introduced each. Enumerating them by hand was the first
+# version of this test and it accepted except* -- the parser knows the whole
+# grammar and a list does not.
+#
+# What feature_version does not decide is the standard library, so the two
+# tables below carry the parts of it that moved after the floor. It also does
+# not reject `int | None` inside an annotation, which is correct: every module
+# here uses `from __future__ import annotations`, so an annotation is never
+# evaluated. A PEP 604 union in a *runtime* position -- isinstance, a cast, a
+# default -- would run on 3.9 and is not caught here.
+ATTRIBUTES_ABOVE_FLOOR = {
+    "batched": (3, 12),  # itertools
+    "pairwise": (3, 10),  # itertools
+}
+MODULES_ABOVE_FLOOR = {
+    "tomllib": (3, 11),
+}
+
+
+def _sources() -> list[Path]:
+    paths = [
+        path
+        for directory in ("scripts", "tests")
+        for path in sorted((ROOT / directory).rglob("*.py"))
+        if "__pycache__" not in path.parts
+    ]
+    assert paths, "no Python sources found; the layout moved"
+    return paths
+
+
+@pytest.mark.parametrize("path", _sources(), ids=lambda p: str(p.relative_to(ROOT)))
+def test_source_stays_within_the_declared_floor(path: Path) -> None:
+    """No script uses syntax or a library API newer than the floor."""
+    source = path.read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(source, filename=str(path), feature_version=FLOOR)
+    except SyntaxError as error:  # pragma: no cover - the failure this guards
+        pytest.fail(
+            f"{path.relative_to(ROOT)} does not parse as Python "
+            f"{FLOOR[0]}.{FLOOR[1]}: line {error.lineno}: {error.msg}"
+        )
+
+    offences: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and node.attr in ATTRIBUTES_ABOVE_FLOOR:
+            version = ATTRIBUTES_ABOVE_FLOOR[node.attr]
+            offences.append(
+                f"line {node.lineno}: .{node.attr} needs {version[0]}.{version[1]}"
+            )
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            names = (
+                [alias.name for alias in node.names]
+                if isinstance(node, ast.Import)
+                else [node.module or ""]
+            )
+            for name in names:
+                version = MODULES_ABOVE_FLOOR.get(name.split(".")[0])
+                if version is not None:
+                    offences.append(
+                        f"line {node.lineno}: {name} needs {version[0]}.{version[1]}"
+                    )
+
+    assert not offences, (
+        f"{path.relative_to(ROOT)} exceeds the declared Python "
+        f"{FLOOR[0]}.{FLOOR[1]} floor:\n  " + "\n  ".join(offences)
+    )
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    ["scripts/setup.sh", "scripts/agent_gate.sh"],
+)
+def test_bootstrap_guards_the_same_floor(relative_path: str) -> None:
+    """Both entry points refuse an interpreter below the floor, in the same words."""
+    text = (ROOT / relative_path).read_text(encoding="utf-8")
+    guard = f"sys.version_info >= ({FLOOR[0]}, {FLOOR[1]})"
+    assert guard in text, (
+        f"{relative_path} does not check for Python {FLOOR[0]}.{FLOOR[1]}; "
+        "a contributor below the floor meets an AttributeError instead of a sentence"
+    )
+    assert f"Python {FLOOR[0]}.{FLOOR[1]} or newer" in text, (
+        f"{relative_path} checks the floor but does not name it in the error"
+    )
+
+
+def test_readme_names_the_floor() -> None:
+    """The onboarding claim matches what the code needs."""
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    assert "pure-stdlib Python 3" not in readme, (
+        "README claims a pure-stdlib requirement; check_conjecture_grade_prose "
+        "imports PyYAML and six validators need 3.9"
+    )
+    assert f"Python {FLOOR[0]}.{FLOOR[1]} or\nnewer" in readme, (
+        "README does not state the Python floor the validators enforce"
+    )
+
+
+def test_the_floor_test_would_notice_newer_syntax(tmp_path: Path) -> None:
+    """The parser check is load-bearing: syntax above the floor must not pass.
+
+    ``except*`` is the case that motivated it. The first version of this file
+    enumerated constructs by hand, and a hand-written list has no reason to
+    contain a construct nobody has used yet.
+    """
+    for source, introduced in (
+        ("try:\n    pass\nexcept* ValueError:\n    pass\n", "3.11"),
+        ("match x:\n    case 1:\n        pass\n", "3.10"),
+        ("type Alias = int\n", "3.12"),
+    ):
+        with pytest.raises(SyntaxError):
+            ast.parse(source, feature_version=FLOOR)
+        assert ast.parse(source), f"the {introduced} sample is not valid on this interpreter"
+
+
+def test_suite_collects_without_pyyaml(tmp_path: Path) -> None:
+    """PyYAML absent must skip a module, not interrupt collection.
+
+    agent_gate.sh skips the standalone conjecture-prose check when PyYAML is
+    missing, but the checker is also imported by a pytest module. Without a
+    skip there, the gate's own pytest step fails collection and takes the whole
+    suite with it -- so the gate's notice would promise something untrue.
+    """
+    blocker = tmp_path / "sitecustomize.py"
+    blocker.write_text("import sys\nsys.modules['yaml'] = None\n", encoding="utf-8")
+
+    environment = dict(os.environ)
+    existing = environment.get("PYTHONPATH")
+    environment["PYTHONPATH"] = (
+        str(tmp_path) if existing is None else f"{tmp_path}{os.pathsep}{existing}"
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "pytest",
+            str(ROOT / "tests" / "test_conjecture_grade_prose.py"),
+            "-q", "--no-header", "-p", "no:cacheprovider",
+        ],
+        cwd=ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    # 0 is a clean run and 5 is "everything in this run was skipped"; the
+    # regression is 2, which pytest returns for an interrupted collection and
+    # which takes every other test module down with it.
+    assert result.returncode in (0, 5), (
+        "PyYAML absent interrupted collection:\n" + result.stdout + result.stderr
+    )
+    assert "skipped" in result.stdout, result.stdout
+    assert "error" not in result.stdout.lower(), result.stdout


### PR DESCRIPTION
## Summary

`README.md` and `scripts/setup.sh` both described the validators as "pure-stdlib
Python 3". Neither half of that was true, and each false half had its own
failure mode for a new contributor following the "No toolchain needed" path.

On Ubuntu 20.04, whose `python3` is still 3.8.10 — reproduced on a clean
checkout of `main` at d7ec5b9:

```console
$ scripts/setup.sh --pointer
==> validate_registry
Traceback (most recent call last):
  File "scripts/validate_registry.py", line 273, in normalize_module_name
    return value.removesuffix(".lean").replace("/", ".")
AttributeError: 'str' object has no attribute 'removesuffix'
```

and with a 3.9+ interpreter but no PyYAML:

```console
$ ./scripts/agent_gate.sh
==> check_conjecture_grade_prose
ModuleNotFoundError: No module named 'yaml'
```

Both read as a bug in whichever validator happened to run first, rather than as
an unmet requirement — which is the wrong place to send someone whose first
contact with the repository this is.

**The floor was measured, not chosen.** `str.removesuffix`, `str.removeprefix`
and `functools.cache` are all 3.9, and ten call sites across six validators use
them (`validate_registry`, `check_print_axioms`, `check_audit_coverage`,
`check_drift_coverage`, `check_elaboration_drift`, `generate_dependency_graph`).
Nothing in `scripts/` or `tests/` needs 3.10 or later: all 56 files parse under
`ast.parse(..., feature_version=(3, 9))`. So no validator code changes here —
3.9 is stated and enforced, and raising it further would exclude platforms for
no gain.

## Unique value

Not a formalization. This is onboarding correctness: the repository's own
documented entry point failed on a supported platform, and the gate's
optional-dependency contract was stated but not kept.

The second half is the less obvious one. `agent_gate.sh` skips `pytest` and `ty`
with a notice when absent; PyYAML got no such treatment, and adding the obvious
skip is not sufficient, because `tests/test_conjecture_grade_prose.py` executes
the checker at import. With PyYAML absent that fails **collection** — pytest
exits 2 and takes the entire suite with it, not just that module. So the gate
would have printed `skipping (CI runs it)` and then failed at its own pytest
step regardless. Both halves are fixed, and the pytest half is what makes the
notice honest.

## Evidence and provenance

No sources, declarations or licenses are involved; no coverage claim moves.

Verified across five environments on the branch head:

| environment | result |
|---|---|
| 3.13 + pytest + ty + PyYAML | `300 passed, 1 skipped`; `ty` clean; gate green |
| 3.13 + pytest, PyYAML blocked | `267 passed, 2 skipped`; gate green, **exit 0** (was exit 2) |
| 3.13, standard library only | three skip notices, gate green |
| 3.8.10 (`/usr/bin/python3`) | one-line error, exit 1, from **both** `setup.sh` and `agent_gate.sh` |
| parser | all 56 files parse at `feature_version=(3, 9)` |

`python3 scripts/validate_registry.py` and `python3 scripts/audit_release.py`
both pass unchanged. `bash -n` passes on both shell scripts and
`git diff --check` is clean. PyYAML was blocked with `sys.modules['yaml'] = None`
via `sitecustomize.py` rather than by uninstalling it, so the runs above are
reproducible without disturbing an environment.

The new regression test was mutation-checked: with the `importorskip` removed it
fails with `assert 2 in (0, 5)`, and passes with it restored.

## Public API and interpretation

None. No Lean file is touched, no declaration is added or renamed, no registry
row changes, and no AI-safety interpretation is asserted. `lake build` is
therefore not exercised by this branch — the cheap gate is, in full.

## What is in `tests/test_python_floor.py`

Syntax is left to the parser rather than to a list. The first draft of this test
enumerated constructs by hand and accepted `except*`; `feature_version=(3, 9)`
rejects `match`, `except*`, PEP 695 type aliases and generic parameter lists on
its own, and reports which version introduced each. A hand-written list has no
reason to contain a construct nobody has written yet.

Library APIs that moved after the floor are still enumerated, because the parser
has no opinion on `itertools.batched`. One limitation is recorded in the
docstring rather than half-solved: `feature_version` accepts `int | None` inside
an annotation, which is right here because every module carries
`from __future__ import annotations`, but a PEP 604 union in a runtime position
would not be caught.

The remaining tests hold the documents to the code: both bootstrap scripts must
check the floor and name it in the error, `README.md` must not re-acquire the
"pure-stdlib" claim, and a subprocess run with PyYAML blocked must skip rather
than interrupt.

## Checklist

- [x] I checked for an existing maintained formalization before adding a proof. — n/a, no proof
- [x] I updated registry and status evidence where coverage claims changed. — n/a, none changed
- [x] I recorded attribution, immutable versions, and licenses for adapted work. — n/a, nothing adapted
- [x] `lake build` passes without incomplete proofs. — n/a, no Lean touched; `./scripts/agent_gate.sh` green instead
- [x] `python3 scripts/validate_registry.py` passes.
- [x] `python3 scripts/audit_release.py` passes.
- [x] I kept unrelated and local-only files out of this pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011XCmjkYbgPy7pxQUu5ZqvJ
