### PR TITLE
Take the migration gate baseline from the branch point

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          # check_migration_adjudicated.py reads lean-toolchain at the recorded
-          # baseline commit to decide whether this branch is a toolchain bump.
-          # A depth-1 checkout does not have that commit, and a check that
-          # cannot see its baseline would skip exactly when it is needed.
+          # check_migration_adjudicated.py reads lean-toolchain at the merge
+          # base with origin/main to decide whether this branch is a toolchain
+          # bump, falling back to the recorded baseline commit. A depth-1
+          # checkout has neither, and a check that cannot see its baseline
+          # would skip exactly when it is needed.
           fetch-depth: 0
       # The gate skips tests/ when pytest is absent so a contributor without it
       # still gets every other check. CI installs it, so the skip never applies

--- a/scripts/check_migration_adjudicated.py
+++ b/scripts/check_migration_adjudicated.py
@@ -27,6 +27,12 @@ The record is a countersignature, not a proof: it says a human looked at each
 difference and judged it. What is enforced here is that the looking happened and
 that its subject is still the tree in front of us.
 
+The baseline defaults to the merge base with ``origin/main`` -- the tree this
+branch departs from -- and falls back to the recorded ``baseline_commit`` when
+that ref is not in the checkout. It is deliberately *not* the recorded pin by
+default: that pin names the commit one migration was measured against, so
+defaulting to it makes every later branch read as a migration.
+
 Usage:
     python3 scripts/check_migration_adjudicated.py
     python3 scripts/check_migration_adjudicated.py --ref <commit>
@@ -44,6 +50,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 BASELINE = ROOT / "docs" / "status" / "migration-baseline.json"
 TOOLCHAIN = "lean-toolchain"
+UPSTREAM = "origin/main"
 
 DRIFT_RE = re.compile(r"^statement drift against .*?: (\d+) difference")
 PROOFS_RE = re.compile(r"(\d+) proof body/bodies also rewritten")
@@ -55,6 +62,26 @@ def git(*args: str) -> str | None:
         ["git", *args], cwd=ROOT, capture_output=True, text=True, check=False
     )
     return proc.stdout if proc.returncode == 0 else None
+
+
+def live_baseline() -> str | None:
+    """The tree this branch actually departs from, which is not the record's pin.
+
+    ``migration-baseline.json`` pins the commit *one* migration was measured
+    against, and says so in its own note: it is a reproduction pin, not the live
+    reference, because "comparing forever against the pre-migration tree would
+    keep the gate red over work that is already accounted for". Defaulting to
+    that pin did what the note warned about -- every branch after the migration
+    merged reads as a migration, and the recorded difference count can then only
+    be matched by a branch that adds no declarations, which is to say by no Lean
+    contribution at all.
+
+    The merge base with the upstream default branch is the honest answer to "did
+    *this branch* move the toolchain". Falls back to the recorded pin when that
+    ref is not in the checkout, so a shallow clone behaves as before.
+    """
+    base = git("merge-base", "HEAD", UPSTREAM)
+    return base.strip() or None if base is not None else None
 
 
 def toolchain_at(ref: str) -> str | None:
@@ -97,7 +124,8 @@ def main() -> int:
     parser.add_argument(
         "--ref",
         default=None,
-        help="baseline to compare against; defaults to the recorded baseline_commit",
+        help="baseline to compare against; defaults to the merge base with "
+        f"{UPSTREAM}, or to the recorded baseline_commit if that ref is absent",
     )
     arguments = parser.parse_args()
 
@@ -106,6 +134,8 @@ def main() -> int:
         record = json.loads(BASELINE.read_text(encoding="utf-8"))
 
     ref = arguments.ref
+    if ref is None:
+        ref = live_baseline()
     if ref is None:
         if record is None:
             print(

--- a/tests/test_migration_adjudicated.py
+++ b/tests/test_migration_adjudicated.py
@@ -154,3 +154,120 @@ def test_the_real_record_matches_the_real_tree() -> None:
     assert record["migration"]["baseline_commit"]
     assert record["measured"]["statement_drift_differences"] >= 0
     assert len(record["adjudications"]) >= 1
+
+
+# --- The default baseline ---------------------------------------------------
+#
+# Everything above monkeypatches `toolchain_at` and moves ROOT into a plain
+# temporary directory, so `live_baseline()` finds no repository, returns None,
+# and the recorded pin is used. That is the fallback path, and it means none of
+# those tests can tell whether the default was taken from the branch point or
+# from the record -- reverting the default would leave all of them green.
+#
+# These two build a real repository instead and let git answer.
+
+
+def _run(cwd, *args: str) -> str:
+    import subprocess
+
+    proc = subprocess.run(
+        ["git", "-c", "user.name=t", "-c", "user.email=t@example.invalid", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return proc.stdout.strip()
+
+
+def _repo(tmp_path: Path, *, upstream: bool):
+    """A history whose recorded pin and whose branch point disagree.
+
+    * `A` carries the old toolchain and is what the record pins.
+    * `B` carries the new one, and is where `origin/main` points.
+    * `HEAD` is an ordinary feature commit on top of `B` that adds a file --
+      the shape of every contribution made after a migration merges.
+
+    So the recorded pin says "the toolchain moved" and the branch point says it
+    did not, and only one of those is a true statement about this branch.
+    """
+    (tmp_path / "docs" / "status").mkdir(parents=True)
+    # `git init -b` needs git 2.28; Ubuntu 20.04 ships 2.25 and the branch name
+    # is never used here.
+    _run(tmp_path, "init", "-q")
+
+    (tmp_path / "lean-toolchain").write_text("leanprover/lean4:v4.31.0\n", encoding="utf-8")
+    _run(tmp_path, "add", "-A")
+    _run(tmp_path, "commit", "-q", "-m", "before the migration")
+    recorded = _run(tmp_path, "rev-parse", "HEAD")
+
+    (tmp_path / "lean-toolchain").write_text("leanprover/lean4:v4.33.0\n", encoding="utf-8")
+    _run(tmp_path, "add", "-A")
+    _run(tmp_path, "commit", "-q", "-m", "the migration")
+    migrated = _run(tmp_path, "rev-parse", "HEAD")
+    if upstream:
+        _run(tmp_path, "update-ref", "refs/remotes/origin/main", migrated)
+
+    (tmp_path / "new_module.txt").write_text("a declaration this branch adds\n", encoding="utf-8")
+    _run(tmp_path, "add", "-A")
+    _run(tmp_path, "commit", "-q", "-m", "an ordinary feature branch")
+    return recorded
+
+
+def _record_at(tmp_path: Path, recorded: str) -> Path:
+    path = tmp_path / "docs" / "status" / "migration-baseline.json"
+    record = dict(RECORD)
+    record["migration"] = {"baseline_commit": recorded}
+    path.write_text(json.dumps(record), encoding="utf-8")
+    return path
+
+
+def _point_at(monkeypatch, tmp_path: Path, path: Path) -> None:
+    monkeypatch.setattr(gate, "ROOT", tmp_path)
+    monkeypatch.setattr(gate, "BASELINE", path)
+    monkeypatch.setattr(sys, "argv", ["check_migration_adjudicated.py"])
+    # A feature branch must never reach the drift comparison at all: it is not a
+    # migration, so there is nothing to adjudicate. Returning counts that
+    # disagree with the record makes reaching it an audible failure rather than
+    # a silent pass.
+    monkeypatch.setattr(
+        gate,
+        "run_drift",
+        lambda _ref: ("statement drift against main: 38 difference(s)\n", 1),
+    )
+
+
+def test_default_baseline_is_the_branch_point_not_the_recorded_pin(
+    monkeypatch, tmp_path, capsys
+) -> None:
+    """A feature branch cut after a migration is not itself a migration.
+
+    Reverting the default to `record["migration"]["baseline_commit"]` makes this
+    fail: the pin's toolchain is v4.31.0, the tree's is v4.33.0, the gate reads
+    that as a bump, and the 38 measured differences do not match the recorded
+    31.
+    """
+    recorded = _repo(tmp_path, upstream=True)
+    _point_at(monkeypatch, tmp_path, _record_at(tmp_path, recorded))
+
+    assert gate.main() == 0
+    out = capsys.readouterr().out
+    assert "not a migration" in out, out
+    assert recorded[:12] not in out, f"took the recorded pin as its baseline:\n{out}"
+
+
+def test_without_an_upstream_ref_it_falls_back_to_the_recorded_pin(
+    monkeypatch, tmp_path, capsys
+) -> None:
+    """A shallow or forkless checkout keeps the old behaviour rather than none.
+
+    `merge-base` fails when `origin/main` is not in the checkout. The gate has
+    to stay a gate there, so it falls back to the record and -- on this
+    history -- correctly refuses.
+    """
+    recorded = _repo(tmp_path, upstream=False)
+    _point_at(monkeypatch, tmp_path, _record_at(tmp_path, recorded))
+
+    assert gate.main() == 1
+    err = capsys.readouterr().err
+    assert "no longer matches the tree" in err, err


### PR DESCRIPTION
## Summary

- derive the live migration baseline from the merge base with `origin/main`
- retain the recorded migration pin as the fallback and preserve explicit `--ref`
- add real-Git regression coverage for both paths
- update the checker help and CI checkout explanation

This prevents ordinary Lean contributions made after a toolchain migration from being misclassified as new migrations. It changes no Lean declarations or source-fidelity claims.

## Validation

- `python3 -m pytest -q tests/test_migration_adjudicated.py` — 13 passed
- `./scripts/agent_gate.sh` — 302 passed, 1 skipped; `ty` clean
- explicit historical `--ref 4edc041…` check — 31 differences and 4 adjudications reproduced