### PR TITLE
Make the migration gate's completed_commit branch load-bearing in its tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          # check_migration_adjudicated.py reads lean-toolchain at the recorded
-          # baseline commit to decide whether this branch is a toolchain bump.
-          # A depth-1 checkout does not have that commit, and a check that
+          # check_migration_adjudicated.py reads lean-toolchain at the
+          # recorded completed_commit and baseline_commit to decide whether
+          # this branch is a toolchain bump, and tests ancestry against the
+          # first. A depth-1 checkout has neither commit, and a check that
           # cannot see its baseline would skip exactly when it is needed.
           fetch-depth: 0
       # The gate skips tests/ when pytest is absent so a contributor without it

--- a/scripts/check_migration_adjudicated.py
+++ b/scripts/check_migration_adjudicated.py
@@ -111,7 +111,9 @@ def main() -> int:
     parser.add_argument(
         "--ref",
         default=None,
-        help="baseline to compare against; defaults to the recorded baseline_commit",
+        help="baseline to compare against; by default the branch is first tested "
+        "against the record's completed_commit and passes if it descends from that "
+        "commit on the same toolchain, falling back to its baseline_commit",
     )
     arguments = parser.parse_args()
 

--- a/tests/test_migration_adjudicated.py
+++ b/tests/test_migration_adjudicated.py
@@ -48,16 +48,41 @@ RECORD = {
 }
 
 
-def _install(monkeypatch, tmp_path, *, before: str, now: str, record, drift: str = DRIFT_OUTPUT):
+def _install(
+    monkeypatch,
+    tmp_path,
+    *,
+    before: str,
+    now: str,
+    record,
+    drift: str = DRIFT_OUTPUT,
+    at_completed: str | None = None,
+    ancestor: bool = True,
+):
     """Point the gate at a synthetic tree so no test depends on the real one.
 
     ``ROOT`` moves with ``BASELINE`` because the failure messages report the
     record's path relative to the root, and a baseline outside it raises
     ``ValueError`` before the test can see the exit code it came for.
+
+    ``toolchain_at`` answers per ref, not once for all of them. A single answer
+    cannot express the situation the ``completed_commit`` branch exists for --
+    the recorded baseline still on the old toolchain while the completed
+    migration is on the new one -- and a test that cannot express it passes
+    whether or not that branch is there.
     """
-    monkeypatch.setattr(gate, "toolchain_at", lambda _ref: before)
+    completed = None
+    if record is not None:
+        completed = record.get("migration", {}).get("completed_commit")
+
+    def _toolchain_at(ref):
+        if at_completed is not None and completed is not None and ref == completed:
+            return at_completed
+        return before
+
+    monkeypatch.setattr(gate, "toolchain_at", _toolchain_at)
     monkeypatch.setattr(gate, "working_toolchain", lambda: now)
-    monkeypatch.setattr(gate, "is_ancestor", lambda _ref: True)
+    monkeypatch.setattr(gate, "is_ancestor", lambda _ref: ancestor)
     monkeypatch.setattr(gate, "run_drift", lambda _ref: (drift, 1))
     monkeypatch.setattr(sys, "argv", ["check_migration_adjudicated.py"])
 
@@ -126,12 +151,60 @@ def test_an_ordinary_branch_passes(monkeypatch, tmp_path) -> None:
     assert gate.main() == 0
 
 
+DRIFT_AFTER_MIGRATION = (
+    "statement drift against main: 44 difference(s); 0 proof body/bodies also "
+    "rewritten (kernel-checked)\n"
+)
+
+
 def test_a_branch_after_the_completed_migration_passes(monkeypatch, tmp_path) -> None:
-    """New statements after the merged bump are ordinary feature work."""
+    """New statements after the merged bump are ordinary feature work.
+
+    This is the shape the gate shipped red on: ``baseline_commit`` still names
+    the pre-migration tree, so ``before != now`` and the plain equality shortcut
+    cannot fire. Only the ``completed_commit`` branch can pass this. The drift
+    count is deliberately wrong for the record, so falling through to the drift
+    comparison is an audible failure rather than a quiet pass -- delete the
+    ``completed_commit`` block and this test goes red, which is the whole point
+    of writing it this way.
+    """
     completed = json.loads(json.dumps(RECORD))
     completed["migration"]["completed_commit"] = "completed123"
-    _install(monkeypatch, tmp_path, before="v4.33.0", now="v4.33.0", record=completed)
+    _install(
+        monkeypatch,
+        tmp_path,
+        before="v4.31.0",
+        now="v4.33.0",
+        record=completed,
+        at_completed="v4.33.0",
+        drift=DRIFT_AFTER_MIGRATION,
+    )
     assert gate.main() == 0
+
+
+def test_a_branch_not_descended_from_the_completed_migration_still_refuses(
+    monkeypatch, tmp_path
+) -> None:
+    """The shortcut is for descendants of the merged bump, and only those.
+
+    A branch that bumps the toolchain on its own, without descending from the
+    adjudicated one, is a migration and still owes a verdict per difference. If
+    this passes, ``completed_commit`` has stopped being a fact about ancestry
+    and become an unconditional exemption.
+    """
+    completed = json.loads(json.dumps(RECORD))
+    completed["migration"]["completed_commit"] = "completed123"
+    _install(
+        monkeypatch,
+        tmp_path,
+        before="v4.31.0",
+        now="v4.33.0",
+        record=completed,
+        at_completed="v4.33.0",
+        drift=DRIFT_AFTER_MIGRATION,
+        ancestor=False,
+    )
+    assert gate.main() == 1
 
 
 def test_a_fully_adjudicated_bump_passes(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
Follow-up to #56, which fixed the migration gate correctly and shipped the fix untested. Raised as a comment on that PR after it merged; this is the change.

## The fix deletes with the tests still green

On `main` at 87b4c4c, remove lines 140–159 of `scripts/check_migration_adjudicated.py` — the `if arguments.ref is None and record is not None:` block, up to but not including `before = toolchain_at(ref)`:

```
$ python3 -m pytest tests/test_migration_adjudicated.py -q
............                                                             [100%]
12 passed in 0.02s
```

The cause is the harness rather than the new test. `_install` stubbed `toolchain_at` with `lambda _ref: before`, one answer for every ref, so the situation the branch exists for cannot be expressed: the recorded `baseline_commit` still on `v4.31.0` while the completed migration is on `v4.33.0`. With one answer for both, `test_a_branch_after_the_completed_migration_passes` passed `before="v4.33.0"` and returned 0 at the plain `before == now` shortcut, never reaching the code it was named after.

## What this changes

`toolchain_at` now answers per ref, via an `at_completed` parameter, and `is_ancestor` is steerable rather than pinned to `True`.

`test_a_branch_after_the_completed_migration_passes` then asserts the real shape — baseline on the old toolchain, completed migration on the new one, and a drift count that does **not** match the record, so that falling through to the drift comparison fails audibly instead of passing quietly. That is the live failure #57 hit before #56 landed.

After:

```
$ python3 -m pytest tests/test_migration_adjudicated.py -q
13 passed in 0.06s

# with the completed_commit block removed
FAILED tests/test_migration_adjudicated.py::test_a_branch_after_the_completed_migration_passes
1 failed, 12 passed
```

A negative goes in alongside it. `test_a_branch_not_descended_from_the_completed_migration_still_refuses` bumps the toolchain without descending from the adjudicated commit — that is a migration and still owes a verdict per difference. If it passes, `completed_commit` has stopped being a fact about ancestry and become an unconditional exemption.

## Two descriptions that documented the old default

- `scripts/check_migration_adjudicated.py:114` — `--help` said "defaults to the recorded baseline_commit"
- `.github/workflows/ci.yml:31` — the `fetch-depth: 0` comment said the check reads `lean-toolchain` at the recorded baseline commit

Both were true before #56 and are not now. `fetch-depth: 0` is still required, for two commits instead of one.

## Verification

`./scripts/agent_gate.sh` green, `pytest tests/` 322 passed / 1 skipped. No Lean touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011XCmjkYbgPy7pxQUu5ZqvJ