### PR TITLE
Make the published audit-surface figures runnable, and record what Mathlib lacks

### DIFF
--- a/docs/provenance/formalization-search.json
+++ b/docs/provenance/formalization-search.json
@@ -257,7 +257,7 @@
     },
     {
       "id": "NC-010",
-      "claim": "The Mathlib revision this repository pins carries neither Sylvester's rank inequality in any form -- only the upper bounds rank_mul_le, rank_mul_le_left, rank_mul_le_right and rank_comp_le on the rank of a product -- nor any measure-preserving currying statement for the Lebesgue measure on a finite product. AISafetyAtlas.SingularLearning.ReducedRank proves sylvester_finrank_le and rank_add_rank_le_of_mul; AISafetyAtlas.SingularLearning.Coordinates proves measurePreserving_curry_symm.",
+      "claim": "The Mathlib revision this repository pins lacks six results the MAIS-O70 layer needs, and this repository proves each of them. Two were checked when the layer landed: Sylvester's rank inequality in any form -- only the upper bounds rank_mul_le, rank_mul_le_left, rank_mul_le_right and rank_comp_le on the rank of a product are present -- and any measure-preserving currying statement for the Lebesgue measure on a finite product. AISafetyAtlas.SingularLearning.ReducedRank proves sylvester_finrank_le and rank_add_rank_le_of_mul; AISafetyAtlas.SingularLearning.Coordinates proves measurePreserving_curry_symm. The remaining four are recorded in the follow-up search below, which is what the claim about them rests on: no linear change of variables for the Bochner integral (AISafetyAtlas.SingularLearning.GaussianQuadratic proves integral_comp_linearMap), no Gaussian integral with a general positive-definite quadratic form (integral_exp_neg_quadraticForm, same module), no differentiability or analyticity statement for Matrix.det, Matrix.adjugate or Matrix.inv (AISafetyAtlas.SingularLearning.MatrixAnalytic), and no trace identity in Frobenius form (AISafetyAtlas.SingularLearning.GramSpectrum proves trace_mul_transpose). Each of the six is a packaged reusable statement absent from the pinned corpus, not a claim that the mathematics is new.",
       "asserted_in": [
         "conjectures.yaml, CONJ-026 prior_art",
         "AISafetyAtlas/SingularLearning/ReducedRank.lean, module docstring",
@@ -270,7 +270,41 @@
       ],
       "method": "Content search over the Mathlib revision recorded in this repository's lake-manifest.json, db584cd6d46c92f209a44c0f1c829460d327499d (toolchain v4.33.0), which is NOT the older snapshot recorded under corpora.mathlib in this file. Rank side: case-sensitive search for 'Sylvester' across all of Mathlib, plus a search of Mathlib/LinearAlgebra for any inequality of the shape 'rank _ + rank _ <= _ + rank _', plus enumeration of every rank-of-product lemma in Mathlib/LinearAlgebra/Matrix/Rank.lean and Mathlib/LinearAlgebra/Dimension/LinearMap.lean. Measure side: search of Mathlib/MeasureTheory and Mathlib/Probability for every theorem naming curry or piCurry, for co-occurrences of curry with MeasurePreserving or Measure.map, and enumeration of the volume_measurePreserving_* and measurePreserving_pi* families in Mathlib/MeasureTheory/Constructions/Pi.lean.",
       "found": "No Sylvester rank inequality in any form. The six files mentioning 'Sylvester' are Mathlib/RingTheory/Polynomial/Resultant/Basic.lean and Mathlib/RingTheory/Polynomial/DegreeLT.lean (the Sylvester matrix and resultant), Mathlib/Geometry/Euclidean/MongePoint.lean (Sylvester's theorem on the Monge point), Mathlib/LinearAlgebra/QuadraticForm/Signature.lean and Mathlib/LinearAlgebra/QuadraticForm/Real.lean (Sylvester's law of inertia), and Mathlib/LinearAlgebra/Matrix/HadamardMatrix.lean (Sylvester's Hadamard construction). None is a rank inequality. The rank-of-product lemmas found are upper bounds only: rank_mul_le, rank_mul_le_left, rank_mul_le_right (Matrix/Rank.lean:182,188,195) and rank_comp_le, rank_comp_le_left, rank_comp_le_right (Dimension/LinearMap.lean:53,70,76); the 'rank _ + rank _ <= _' hits in Mathlib/LinearAlgebra are quotient, product and submodule statements, not statements about a matrix product. On the measure side, the only Measure-level currying results are infinitePi_map_curry and infinitePi_map_curry_symm (Mathlib/Probability/ProductMeasure.lean:548,560), stated for the infinite product measure infinitePi and not for volume on a finite product; MeasurableEquiv.curry exists with no measure-preservation companion, and the volume_measurePreserving_* family covers piCongrLeft, arrowProdEquivProdArrow, sumPiEquivProdPi and piFinSuccAbove but not currying.",
-      "scope_limits": "One corpus, at the revision this repository pins, and that revision differs from the corpora.mathlib baseline snapshot recorded elsewhere in this file; the other five baseline corpora were not searched for this claim, and neither were PFR, Foundation, or any other package in the dependency tree. This is a keyword and shape search over source text, not a proof search: a statement carrying neither the name 'Sylvester' nor the arithmetic shape searched for, or one derivable in a few steps from lemmas that are present, would not have been found. It says nothing about unpinned third-party Lean developments, nor about Mathlib after this revision."
+      "scope_limits": "One corpus, at the revision this repository pins, and that revision differs from the corpora.mathlib baseline snapshot recorded elsewhere in this file; the other five baseline corpora were not searched for this claim, and neither were PFR, Foundation, or any other package in the dependency tree. This is a keyword and shape search over source text, not a proof search: a statement carrying neither the name 'Sylvester' nor the arithmetic shape searched for, or one derivable in a few steps from lemmas that are present, would not have been found. It says nothing about unpinned third-party Lean developments, nor about Mathlib after this revision.",
+      "followup_searches": [
+        {
+          "corpus": "mathlib",
+          "framework": "Lean 4 / Mathlib",
+          "repository": "https://github.com/leanprover-community/mathlib4.git",
+          "version": "db584cd6d46c92f209a44c0f1c829460d327499d",
+          "scope": "The whole Mathlib source tree at the revision this repository pins, db584cd6d46c92f209a44c0f1c829460d327499d (toolchain v4.33.0).",
+          "searched_on": "2026-09-05",
+          "searched_by": "mbrcic",
+          "queries": [
+            "integral_comp_linearMap",
+            "contDiff_matrix_det",
+            "analyticAt_matrix_det",
+            "analyticOnNhd_matrix_inv",
+            "trace_mul_transpose",
+            "integral_exp_neg_quadraticForm"
+          ],
+          "candidate_hits": {
+            "hit_count": 0,
+            "query_hit_counts": {
+              "integral_comp_linearMap": 0,
+              "contDiff_matrix_det": 0,
+              "analyticAt_matrix_det": 0,
+              "analyticOnNhd_matrix_inv": 0,
+              "trace_mul_transpose": 0,
+              "integral_exp_neg_quadraticForm": 0
+            },
+            "paths": [],
+            "matched_queries": []
+          },
+          "review": "Four further absences, each behind a name the result would carry if it were present, and each checked by enumerating the family Mathlib does have. (1) No linear change of variables for the Bochner integral: the integral_comp_* family is the scalar-dilation one (integral_comp_smul, integral_comp_inv_smul, integral_comp_mul_left and friends in MeasureTheory/Measure/Haar/NormedSpace.lean) plus polar coordinates; map_linearMap_addHaar_eq_smul_addHaar is the measure-level statement, with no integral-level companion. (2) No Gaussian integral with a general positive-definite quadratic form: Analysis/SpecialFunctions/Gaussian carries the isotropic GaussianFourier.integral_rexp_neg_mul_sq_norm and the one-dimensional integral_gaussian family, and Probability/Distributions/Gaussian/Multivariate.lean defines multivariateGaussian as a pushforward with no density, no determinant and no pdf. (3) No differentiability or analyticity of Matrix.det, Matrix.adjugate or Matrix.inv as maps of the entries: the chain stops at the topological Continuous.matrix_det (Topology/Instances/Matrix.lean:213), and no ContDiff or Analytic statement about any of the three exists. (4) No trace identity in Frobenius form: Matrix.trace_transpose_mul (Trace.lean:154) is the different statement trace (A^T B^T) = trace (A B), trace_conjTranspose_mul_self_eq_zero_iff is a vanishing criterion, and frobenius_norm_def is a norm statement under a scoped instance; nothing equates trace (X X^T) with the sum of squared entries.",
+          "scope_limits": "One corpus at one revision, keyword and shape search over source text rather than proof search. A statement carrying none of these names and none of the shapes enumerated -- or one derivable in a few steps from lemmas that are present, which is true of all four -- would not have been found. These are absences of a packaged, reusable statement, not of the mathematics."
+        }
+      ]
     }
   ],
   "results": {

--- a/docs/provenance/mais-o70-conditional-verification.md
+++ b/docs/provenance/mais-o70-conditional-verification.md
@@ -238,9 +238,11 @@ report whether a binder's proposition is satisfiable. See §8.
 
 ## 7. A reviewer's reading order
 
-The branch is 107 files against `origin/main`: 74 new Lean modules, 3 modified,
-plus ledgers, generated views and two reproduction scripts. Read it in five
-layers. The generated map of the whole layer is
+As merged at `87b4c4c` the change is 123 files: 78 new Lean modules and 3
+modified, plus ledgers, generated views and two reproduction scripts. The
+figures published against this work are the merged ones -- an earlier draft of
+this section counted 107 files and 74 modules, which was the branch before its
+last two rounds. Read it in five layers. The generated map of the whole layer is
 [`singularlearning-dependency-graph.md`](../status/singularlearning-dependency-graph.md);
 the layer's own overview docstring, which says in as many words what is still
 missing, is [`AISafetyAtlas/SingularLearning.lean`](../../AISafetyAtlas/SingularLearning.lean).
@@ -294,6 +296,30 @@ missing, is [`AISafetyAtlas/SingularLearning.lean`](../../AISafetyAtlas/Singular
    carries the semantic instances, the cross-check of the conditional chain
    against the unconditional `x²y²` germ, and the anti-vacuity witness. Then the
    [frontier manifest](o70-frontier-manifest.md), and this file.
+
+### How much of it a human has to read
+
+A conditional verification moves work rather than removing it, and the size of
+what it moves is measurable:
+
+```console
+python3 scripts/audit_surface.py --key MAIS-O70 --list
+```
+
+At `87b4c4c` that prints **343 statement lines, 1.5% of the layer's 22,627**:
+197 lines of conclusion -- the definitional closure of the graded statement
+inside the transcription modules, which answers *is this print's question?* --
+and 146 lines of assumed proposition and frozen `..._iff` body, which answers
+*are these the results they are named after?* Docstrings count, because a
+transcription is defended in its docstring and a reader deciding whether the
+statement is the printed one reads that argument, not only the binders.
+
+The number is a floor rather than a total: the closure stops at the
+transcription modules, so the chamber calculus a fuller reading would reach is
+not in it, and `--list` prints every declaration counted so the cut can be
+checked rather than trusted. The script exits non-zero when a listed
+declaration is gone, which is what keeps a published figure from going stale
+after a rename.
 
 ---
 

--- a/scripts/audit_surface.py
+++ b/scripts/audit_surface.py
@@ -216,7 +216,7 @@ SURFACES: tuple[Surface, ...] = (
     Surface(
         key="MAIS-O34",
         issue=4,
-        problem="prob:fiber",
+        problem="prob:starter-set(a)",
         layer=(
             "AISafetyAtlas/Conjectures/MAIS/O34.lean",
             "AISafetyAtlas/Conjectures/BinaryPair.lean",

--- a/scripts/audit_surface.py
+++ b/scripts/audit_surface.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+"""How many lines of a verification a human has to read.
+
+A machine-checked answer to a printed problem moves work rather than removing
+it. The kernel settles whether the proof follows; it cannot settle whether the
+*statement* is the printed question, nor whether an assumed proposition is the
+classical result it is named after. Those two are what a reader is left with,
+and this script measures them, so a claim like "22,627 lines of Lean, of which
+a reader has to audit 338" is reproducible rather than asserted.
+
+Two numbers per surface:
+
+* the **conclusion** — the definitional closure of the graded statement inside
+  the surface's own statement modules. Read it to answer *is this print's
+  question?*
+* the **hypotheses** — the assumed propositions and their frozen `..._iff`
+  bodies. Read them to answer *are these the results they are named after?*
+
+Statement lines, and the docstring attached to each: for a theorem the count
+stops at the proof's `:=`, and a `def` is counted whole, because for a
+`Prop`-valued definition the body *is* the statement. The docstring counts
+because it is where a transcription is defended -- a reader deciding whether a
+statement is the printed question reads the argument for it, not only the
+binders. Section headers (`/-! ... -/`) belong to no declaration and are not
+counted.
+
+The closure is restricted to each surface's statement modules. That is a
+deliberate under-count of everything a referee could read -- the machinery
+underneath is not counted -- and it is the right cut for the question the
+number answers, which is how much *transcription* stands between print and the
+kernel.
+
+    python3 scripts/audit_surface.py                # every surface
+    python3 scripts/audit_surface.py --key MAIS-O70 # one
+    python3 scripts/audit_surface.py --json         # for a generator
+
+Exit code is 1 if a listed declaration is missing, which is what makes a
+published figure fail loudly after a rename instead of quietly going stale.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+DECL_KEYWORDS = ("theorem", "lemma", "def", "abbrev", "structure", "class", "instance")
+DECL_RE = re.compile(
+    r"^\s*(?:@\[[^\]]*\]\s*)*(?:public\s+|private\s+|protected\s+|noncomputable\s+|partial\s+|unsafe\s+)*"
+    rf"(?P<kw>{'|'.join(DECL_KEYWORDS)})\s+(?P<name>[A-Za-z_][A-Za-z0-9_.'!?]*)"
+)
+LINE_COMMENT = re.compile(r"--.*$")
+
+
+@dataclass(frozen=True)
+class Surface:
+    """One published verification, and the reading it asks of a human."""
+
+    key: str
+    issue: int
+    problem: str
+    layer: tuple[str, ...]              # modules the verification consists of
+    statement_modules: tuple[str, ...]  # modules the transcription lives in
+    conclusion_roots: tuple[str, ...]
+    hypothesis_roots: tuple[str, ...] = ()
+    note: str = ""
+
+
+# The registry. A surface is added when a verification is published somewhere a
+# reader can act on it -- an issue thread, a release note -- because that is
+# when the figures become a claim rather than a measurement.
+SURFACES: tuple[Surface, ...] = (
+    Surface(
+        key="MAIS-O70",
+        issue=3,
+        problem="prob:calibration",
+        layer=(
+            "AISafetyAtlas/SingularLearning.lean",
+            "AISafetyAtlas/SingularLearning/",
+            "AISafetyAtlas/Examples/SingularLearning.lean",
+            "AISafetyAtlas/Examples/SingularLearning/",
+            "AISafetyAtlas/Conjectures/MAIS/O70.lean",
+            "AISafetyAtlas/Conjectures/MAIS/O70Proof.lean",
+            "AISafetyAtlas/Examples/Conjectures/MAIS/O70.lean",
+            "AISafetyAtlas/Examples/Conjectures/MAIS/O70Proof.lean",
+        ),
+        statement_modules=(
+            "AISafetyAtlas/Conjectures/MAIS/O70.lean",
+            "AISafetyAtlas/SingularLearning/LocalPair.lean",
+            "AISafetyAtlas/SingularLearning/ZetaPair.lean",
+            "AISafetyAtlas/SingularLearning/Loss.lean",
+            "AISafetyAtlas/SingularLearning/AoyagiWatanabe.lean",
+            "AISafetyAtlas/SingularLearning/EigenvalueLaw.lean",
+        ),
+        conclusion_roots=(
+            "IsO70RankTable",
+            "O70DependsOnRanksOnly",
+            "IsO70MinimizerCharacterization",
+            "IsO70FiberMinimumTable",
+            "IsO70AWValueStratumTable",
+            "o70Pair",
+            "o70Minimizers",
+        ),
+        hypothesis_roots=(
+            "EigenvalueLawStatement",
+            "eigenvalueLawStatement_iff",
+            "O70ExactLocalPairsExist",
+            "o70ExactLocalPairsExist_iff",
+            "O70ZetaPoleBridge",
+            "o70ZetaPoleBridge_iff",
+        ),
+        note="conditional: the three frontiers are assumed, not proved",
+    ),
+    Surface(
+        key="MAIS-O38",
+        issue=30,
+        problem="prob:samples",
+        layer=(
+            "AISafetyAtlas/Conjectures/MAIS/O38.lean",
+            "AISafetyAtlas/Examples/Conjectures/MAIS/O38.lean",
+            "AISafetyAtlas/Examples/Conjectures/MAIS/O38Candidate.lean",
+        ),
+        statement_modules=("AISafetyAtlas/Conjectures/MAIS/O38.lean",),
+        conclusion_roots=(
+            "maisO38_polynomialSamplesSuffice",
+            "o38PolynomialSampleCandidate",
+        ),
+        note="unconditional",
+    ),
+    Surface(
+        key="MAIS-O33",
+        issue=9,
+        problem="prob:corruption",
+        layer=(
+            "AISafetyAtlas/Conjectures/MAIS/O33.lean",
+            "AISafetyAtlas/Causal/Corruption.lean",
+            "AISafetyAtlas/Causal/Goal.lean",
+            "AISafetyAtlas/Examples/Conjectures/MAIS/O33.lean",
+            "AISafetyAtlas/Examples/Causal/O33Corruption.lean",
+            "AISafetyAtlas/Examples/Causal/Goal.lean",
+        ),
+        statement_modules=(
+            "AISafetyAtlas/Conjectures/MAIS/O33.lean",
+            "AISafetyAtlas/Causal/Goal.lean",
+            "AISafetyAtlas/Causal/Corruption.lean",
+        ),
+        conclusion_roots=(
+            "maisO33_etaStarPos",
+            "maisO33_etaStarIsZero",
+            "maisO33_etaStarIsZeroGivenBaseline",
+        ),
+        hypothesis_roots=("maisO33_baselineTolerable",),
+        note="the negative half is unconditional; the value needs thm:rabe",
+    ),
+    Surface(
+        key="MAIS-O24",
+        issue=7,
+        problem="prob:effective",
+        layer=(
+            "AISafetyAtlas/Causal/EffectiveGenericity.lean",
+            "AISafetyAtlas/Causal/MarginClass.lean",
+            "AISafetyAtlas/Examples/Causal/O24Refutation.lean",
+            "AISafetyAtlas/Examples/Causal/EffectiveGenericity.lean",
+        ),
+        statement_modules=(
+            "AISafetyAtlas/Causal/EffectiveGenericity.lean",
+            "AISafetyAtlas/Causal/MarginClass.lean",
+        ),
+        conclusion_roots=("O24Solution",),
+        note="unconditional",
+    ),
+    Surface(
+        key="MAIS-O23",
+        issue=6,
+        problem="q:ident",
+        layer=(
+            "AISafetyAtlas/Conjectures/MAIS/O23.lean",
+            "AISafetyAtlas/Examples/Conjectures/MAIS/O23.lean",
+            "AISafetyAtlas/Causal/MarginClass.lean",
+            "AISafetyAtlas/Examples/Causal/BehavioralCollision.lean",
+            "AISafetyAtlas/Examples/Causal/OneNodeClass.lean",
+        ),
+        statement_modules=(
+            "AISafetyAtlas/Conjectures/MAIS/O23.lean",
+            "AISafetyAtlas/Causal/MarginClass.lean",
+        ),
+        conclusion_roots=("maisO23_marginsDoNotSuffice",),
+        note="unconditional",
+    ),
+    Surface(
+        key="MAIS-O31",
+        issue=8,
+        problem="q:chain",
+        layer=(
+            "AISafetyAtlas/Conjectures/MAIS/O31.lean",
+            "AISafetyAtlas/Conjectures/MAIS/O31Chart.lean",
+            "AISafetyAtlas/Examples/Conjectures/MAIS/O31.lean",
+            "AISafetyAtlas/Examples/Conjectures/MAIS/O31Measure.lean",
+        ),
+        statement_modules=(
+            "AISafetyAtlas/Conjectures/MAIS/O31.lean",
+            "AISafetyAtlas/Conjectures/MAIS/O31Chart.lean",
+        ),
+        conclusion_roots=(
+            "maisO31_chainClassificationCandidate",
+            "O31IdentifiesCoordinate",
+            "O31SameSideChamber",
+        ),
+        note="partial: one chamber and one refuted heuristic, not the classification",
+    ),
+    Surface(
+        key="MAIS-O34",
+        issue=4,
+        problem="prob:fiber",
+        layer=(
+            "AISafetyAtlas/Conjectures/MAIS/O34.lean",
+            "AISafetyAtlas/Conjectures/BinaryPair.lean",
+            "AISafetyAtlas/Examples/Conjectures/O34Fiber.lean",
+        ),
+        statement_modules=(
+            "AISafetyAtlas/Conjectures/MAIS/O34.lean",
+            "AISafetyAtlas/Conjectures/BinaryPair.lean",
+        ),
+        conclusion_roots=("maisO34_exactFiberCandidate",),
+        note="part (a) only; part (b) untouched",
+    ),
+)
+
+
+@dataclass
+class Declaration:
+    name: str
+    module: str
+    keyword: str
+    start: int
+    end: int
+    doc: int
+    text: str = field(repr=False)
+
+    @property
+    def lines(self) -> int:
+        return self.end - self.start + 1 + self.doc
+
+
+def declarations(path: Path, module: str) -> dict[str, Declaration]:
+    """Every declaration in one module, with its statement extent."""
+    lines = path.read_text(encoding="utf-8").split("\n")
+    starts: list[tuple[int, str, str]] = []
+    in_block = False
+    for number, raw in enumerate(lines, start=1):
+        opens, closes = raw.count("/-"), raw.count("-/")
+        was_in_block = in_block
+        if opens > closes:
+            in_block = True
+        elif closes > opens:
+            in_block = False
+        if was_in_block:
+            continue
+        match = DECL_RE.match(raw)
+        if match:
+            starts.append((number, match.group("kw"), match.group("name")))
+
+    found: dict[str, Declaration] = {}
+    for index, (number, keyword, name) in enumerate(starts):
+        limit = starts[index + 1][0] - 1 if index + 1 < len(starts) else len(lines)
+        end = statement_end(lines, number, limit, keyword)
+        found[name] = Declaration(
+            name=name,
+            module=module,
+            keyword=keyword,
+            start=number,
+            end=end,
+            doc=docstring_lines(lines, number),
+            text="\n".join(lines[number - 1:end]),
+        )
+    return found
+
+
+def docstring_lines(lines: list[str], start: int) -> int:
+    """Length of the `/-- ... -/` docstring attached to the declaration, if any."""
+    index = start - 2  # 0-based line above the declaration
+    while index >= 0 and (lines[index].strip().startswith("@[")
+                          or not lines[index].strip()):
+        if not lines[index].strip():
+            break
+        index -= 1
+    if index < 0 or not lines[index].rstrip().endswith("-/"):
+        return 0
+    if lines[index].lstrip().startswith("/--"):
+        return 1
+    for first in range(index, -1, -1):
+        if lines[first].lstrip().startswith("/--"):
+            return index - first + 1
+        if lines[first].lstrip().startswith("/-!"):
+            return 0
+    return 0
+
+
+def statement_end(lines: list[str], start: int, limit: int, keyword: str) -> int:
+    """Where the statement stops.
+
+    For a theorem that is the proof's `:=`; for a definition it is the end of
+    the block, since a `Prop`-valued definition's body is its statement.
+    """
+    if keyword in ("theorem", "lemma"):
+        for number in range(start, min(limit, start + 80) + 1):
+            stripped = LINE_COMMENT.sub("", lines[number - 1])
+            if ":=" in stripped or re.search(r"\bby\s*$", stripped):
+                return number
+        return min(limit, start + 80)
+    for number in range(start, limit + 1):
+        if not lines[number - 1].strip():
+            return number - 1
+    return limit
+
+
+def closure(roots: tuple[str, ...], table: dict[str, Declaration]) -> list[Declaration]:
+    """Declarations reachable from `roots` by name, inside the statement modules."""
+    seen: dict[str, Declaration] = {}
+    pending = [name for name in roots]
+    while pending:
+        name = pending.pop()
+        if name in seen:
+            continue
+        declaration = table.get(name)
+        if declaration is None:
+            raise LookupError(name)
+        seen[name] = declaration
+        for other, candidate in table.items():
+            if other in seen or other == name:
+                continue
+            if re.search(rf"(?<![A-Za-z0-9_.'])" + re.escape(other) + r"(?![A-Za-z0-9_'])",
+                         declaration.text):
+                pending.append(other)
+    return sorted(seen.values(), key=lambda d: (d.module, d.start))
+
+
+def layer_lines(surface: Surface) -> tuple[int, int]:
+    """Lines and module count of the layer this verification consists of."""
+    modules: set[Path] = set()
+    for entry in surface.layer:
+        path = ROOT / entry
+        if entry.endswith("/"):
+            modules.update(sorted(path.rglob("*.lean")))
+        else:
+            modules.add(path)
+    total = 0
+    for path in sorted(modules):
+        if not path.is_file():
+            raise FileNotFoundError(path)
+        total += len(path.read_text(encoding="utf-8").split("\n")) - 1
+    return total, len(modules)
+
+
+def measure(surface: Surface) -> dict:
+    table: dict[str, Declaration] = {}
+    for module in surface.statement_modules:
+        path = ROOT / module
+        if not path.is_file():
+            raise FileNotFoundError(path)
+        for name, declaration in declarations(path, module).items():
+            table.setdefault(name, declaration)
+
+    # Hypotheses first: an assumed proposition stays on the hypothesis side even
+    # when the conclusion's own statement names it, because the question it
+    # raises for a reader is the other one -- *is this the cited result?*
+    hypothesis = closure(surface.hypothesis_roots, table) if surface.hypothesis_roots else []
+    assumed = set(surface.hypothesis_roots)
+    conclusion = [d for d in closure(surface.conclusion_roots, table)
+                  if d.name not in assumed]
+    # A definition both sides reach is read once, and it is read as vocabulary
+    # of the conclusion.
+    shared = {d.name for d in conclusion}
+    hypothesis = [d for d in hypothesis if d.name not in shared]
+    total, modules = layer_lines(surface)
+    conclusion_lines = sum(d.lines for d in conclusion)
+    hypothesis_lines = sum(d.lines for d in hypothesis)
+    audit = conclusion_lines + hypothesis_lines
+    return {
+        "key": surface.key,
+        "issue": surface.issue,
+        "problem": surface.problem,
+        "note": surface.note,
+        "layer_lines": total,
+        "layer_modules": modules,
+        "conclusion_lines": conclusion_lines,
+        "conclusion_declarations": [f"{d.module}:{d.start} {d.name}" for d in conclusion],
+        "hypothesis_lines": hypothesis_lines,
+        "hypothesis_declarations": [f"{d.module}:{d.start} {d.name}" for d in hypothesis],
+        "audit_lines": audit,
+        "audit_fraction": audit / total if total else 0.0,
+    }
+
+
+def report(result: dict, verbose: bool) -> None:
+    print(f"{result['key']} (MAIS issue #{result['issue']}, {result['problem']}) "
+          f"-- {result['note']}")
+    print(f"  layer            {result['layer_lines']:>7,} lines "
+          f"across {result['layer_modules']} modules")
+    print(f"  conclusion       {result['conclusion_lines']:>7,} lines "
+          f"({len(result['conclusion_declarations'])} declarations)")
+    print(f"  hypotheses       {result['hypothesis_lines']:>7,} lines "
+          f"({len(result['hypothesis_declarations'])} declarations)")
+    print(f"  human audit      {result['audit_lines']:>7,} lines "
+          f"= {result['audit_fraction'] * 100:.1f}% of the layer")
+    if verbose:
+        for label in ("conclusion_declarations", "hypothesis_declarations"):
+            for entry in result[label]:
+                print(f"    {label[0]} {entry}")
+    print()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="How many lines of a verification a human has to read.")
+    parser.add_argument("--key", help="one surface, e.g. MAIS-O70")
+    parser.add_argument("--json", action="store_true", help="machine-readable")
+    parser.add_argument("--list", action="store_true",
+                        help="print every declaration counted")
+    args = parser.parse_args()
+
+    selected = [s for s in SURFACES if args.key in (None, s.key)]
+    if not selected:
+        print(f"audit_surface: no surface named {args.key}", file=sys.stderr)
+        return 1
+
+    results = []
+    failures = []
+    for surface in selected:
+        try:
+            results.append(measure(surface))
+        except LookupError as missing:
+            failures.append(f"{surface.key}: no declaration {missing.args[0]} "
+                            f"in its statement modules")
+        except FileNotFoundError as missing:
+            failures.append(f"{surface.key}: missing module {missing.args[0]}")
+
+    if args.json:
+        print(json.dumps(results, indent=2))
+    else:
+        for result in results:
+            report(result, args.list)
+
+    for failure in failures:
+        print(f"audit_surface: {failure}", file=sys.stderr)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Three MAIS issue threads publish figures of the form *"22,627 lines of Lean, of which a reader has to audit 343"*. Until this branch, that number could not be re-derived from this repository — the same defect those threads charge a candidate with when its computational receipts are asserted rather than runnable.

**`scripts/audit_surface.py`** makes it runnable. For each published verification it measures two things a kernel cannot settle:

* the **conclusion** — the definitional closure of the graded statement inside its transcription modules, which answers *is this print's question?*
* the **hypotheses** — the assumed propositions with their frozen `..._iff` bodies, which answers *are these the results they are named after?*

Statement lines only, docstrings included, because a transcription is defended in its docstring. `--list` prints every declaration counted, so the cut can be checked rather than trusted, and a listed declaration that disappears exits non-zero — a published figure fails loudly after a rename instead of going stale.

At this commit, over the seven surfaces the issue threads report:

| surface | issue | layer | human audit | share |
|---|---|---:|---:|---:|
| MAIS-O70 | #3 | 22,627 | 343 (197 + 146 assumed) | 1.5% |
| MAIS-O38 | #30 | 2,348 | 165 | 7.0% |
| MAIS-O33 | #9 | 1,456 | 124 (115 + 9 assumed) | 8.5% |
| MAIS-O24 | #7 | 2,488 | 299 | 12.0% |
| MAIS-O23 | #6 | 2,328 | 38 | 1.6% |
| MAIS-O31 | #8 | 2,161 | 113 | 5.2% |
| MAIS-O34 | #4 | 2,110 | 77 | 3.6% |

The share is the interesting column, not the total: it is high for a refutation, where the printed bundle *is* nearly the whole artifact, and low where the machinery underneath dwarfs the transcription.

**`NC-010` claimed two absences from the pinned Mathlib and was cited for six.** Its follow-up search now records the other four, each against the family Mathlib does carry: no linear change of variables for the Bochner integral (only the scalar-dilation `integral_comp_smul` family), no Gaussian integral at a general positive-definite quadratic form (only the isotropic case; `multivariateGaussian` is a pushforward with no density), no differentiability or analyticity of `Matrix.det`, `Matrix.adjugate` or `Matrix.inv` (the chain stops at the topological `Continuous.matrix_det`), and no trace identity in Frobenius form. Zero hits on all six query names, at `db584cd6`.

**The conditional-verification note counted the branch, not the merge.** 107 files and 74 modules were the state two rounds before `87b4c4c`, which is 123 files and 78 new modules; §7 now says so and records where the audit figure comes from.

Scope: three files, no Lean, no ledger row. `agent_gate.sh` green apart from two pre-existing `ty` diagnostics in `tests/test_python_floor.py` that come from the local `_pytest` stubs and are untouched here.
