### PR TITLE
Trigger the elaboration-drift check on what causes drift, not on file extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
           && 75 || 30 }}
     outputs:
       run_lean: ${{ steps.filter.outputs.run_lean }}
+      run_migration: ${{ steps.filter.outputs.run_migration }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -128,6 +129,35 @@ jobs:
           fi
           echo "run_lean=$run_lean" >> "$GITHUB_OUTPUT"
           echo "Lean build required: $run_lean"
+
+          # A migration is decided by the toolchain moving, not by anybody's
+          # intent -- the same rule check_migration_adjudicated.py applies, and
+          # for the same reason: a branch that means to bump the toolchain and a
+          # branch that bumps it by accident need the same check to run. The
+          # baseline dump counts because re-dumping it *is* the migration act,
+          # and a branch that rewrites the baseline without re-comparing against
+          # it would otherwise gate itself out of the only check that reads it.
+          migration_pattern='(^lean-toolchain$|^lakefile\.toml$|^lake-manifest\.json$|^docs/status/elab-baseline-.*\.json$)'
+          run_migration=false
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            if git diff --name-only "${{ github.event.pull_request.base.sha }}" \
+                 "${{ github.event.pull_request.head.sha }}" \
+                 | grep -E "$migration_pattern" >/dev/null; then
+              run_migration=true
+            fi
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            before="${{ github.event.before }}"
+            if [ -n "$before" ] && [ "$before" != "0000000000000000000000000000000000000000" ]; then
+              if git diff --name-only "$before" "${{ github.sha }}" \
+                   | grep -E "$migration_pattern" >/dev/null; then
+                run_migration=true
+              fi
+            else
+              run_migration=true
+            fi
+          fi
+          echo "run_migration=$run_migration" >> "$GITHUB_OUTPUT"
+          echo "Toolchain migration: $run_migration"
       - name: Skip notice
         if: steps.filter.outputs.run_lean != 'true'
         run: echo "No Lean-related paths changed; skipping lake build and axiom check."
@@ -231,22 +261,67 @@ jobs:
       # fail on the one bucket an ordinary branch can be held to. `--fatal
       # silent` is the whole reason this is gateable. Adding, removing or
       # visibly editing a statement is what a branch is for and would make a
-      # plain --compare red on every ordinary PR, which is why it was left
-      # unwired; but a declaration whose printed type is unchanged cannot have
-      # changed meaning through an edit, so a silent change is never work
-      # anyone asked for.
+      # plain --compare red on every ordinary PR; a declaration whose printed
+      # type is unchanged cannot have changed meaning through an edit, so a
+      # silent change is never work anyone asked for.
+      #
+      # WHEN IT RUNS -- toolchain migrations, the two schedules, release tags
+      # and manual runs. NOT on an ordinary pull request, and this is a change
+      # from how it was first wired.
+      #
+      # The dump elaborates the whole environment: 342 s and 2.2 GB on an idle
+      # 12-core host against a tree the steps above have already built, slower
+      # on a two-core hosted runner. It was the largest single step on an
+      # ordinary pull request, against a job budget of 30 minutes.
+      #
+      # It now runs on:
+      #
+      #   * `run_migration` -- lean-toolchain, lakefile.toml, lake-manifest.json
+      #     or a baseline dump moved. This is the dominant cause, and it fires on
+      #     the pull request that does it, before the merge, exactly as before.
+      #     lakefile.toml is in the list on its own account and not only through
+      #     the manifest: `leanOptions` such as autoImplicit or pp settings
+      #     change elaboration with no manifest movement at all.
+      #   * `schedule` -- both crons. The weekly one exists to catch Mathlib CDN
+      #     and toolchain drift, which is this check's own failure mode and
+      #     arrives with no commit attached; the nightly one bounds how long any
+      #     silent change can sit unnoticed to a day.
+      #   * release tags and `workflow_dispatch` -- nothing ships unverified,
+      #     and anyone who wants the answer now can have it.
+      #
+      # WHAT THIS GIVES UP, stated because it is a trade and not a free saving.
+      # Silent drift is usually caused by the environment moving under unchanged
+      # source, and those causes are all still gated above. But an ordinary
+      # atlas pull request *can* produce it: adding a typeclass instance changes
+      # resolution for declarations nobody edited, and so can an attribute, a
+      # notation, or a change to a definition's implicit arguments. In each case
+      # the printed type is unchanged and the elaborated type is not. That is
+      # the case that now waits for the nightly run instead of blocking the pull
+      # request, so the exposure window is a day rather than zero.
+      #
+      # It has never been observed firing on such a pull request here, and 342 s
+      # on every Lean-touching PR is a certain cost against an uncertain one --
+      # the maintainer's call, taken deliberately. If it starts catching things
+      # nightly that a PR introduced, the trade is wrong and this should go back.
+      #
+      # This mirrors the leanchecker gating below, with `run_migration` added
+      # because that is the event this check answers to and leanchecker does
+      # not. The decision, the cost ladder for every check in this job, and the
+      # window each gating leaves open are recorded in
+      # docs/provenance/verification-scheduling.md -- read that before changing
+      # a trigger here.
       #
       # Expect it to go red on a toolchain bump. That is correct and is the
       # point: re-adjudicate the silent set, re-dump the baseline, and record
-      # the classes. Do not widen the flag.
-      #
-      # Cost: the dump elaborates the whole environment, measured at 342 s and
-      # 2.2 GB on an idle 12-core host against a tree the steps above have
-      # already built; a two-core hosted runner is slower. That is the largest
-      # single step on an ordinary pull request, so read it against this job's
-      # 30-minute budget before adding anything else here.
+      # the classes. Do not widen the flag, and do not restore the unfiltered
+      # trigger without measuring the step again.
       - name: No statement changed meaning behind an unchanged printed type
-        if: steps.filter.outputs.run_lean == 'true'
+        if: >-
+          steps.filter.outputs.run_lean == 'true' &&
+          (steps.filter.outputs.run_migration == 'true' ||
+           github.event_name == 'schedule' ||
+           github.event_name == 'workflow_dispatch' ||
+           startsWith(github.ref, 'refs/tags/v'))
         run: |
           set -euo pipefail
           dump="$RUNNER_TEMP/elab-current.json"

--- a/docs/README.md
+++ b/docs/README.md
@@ -76,6 +76,9 @@ in the repository can detect it.
   readings that are choices rather than transcriptions
 - [Toolchain v4.33.0 migration](provenance/toolchain-v4330-migration.md) — what
   moved, what broke, and which build records were deliberately not rewritten
+- [Verification scheduling](provenance/verification-scheduling.md) — what CI runs
+  on which trigger and why: the cost ladder, the two gated checks, and the window
+  each gating leaves open
 - [MAIS source pin](provenance/mais-source-pin.md) — the commit and per-file SHA-256
   the MAIS-A2 grading is anchored to
 - [MAIS-O70 conditional verification](provenance/mais-o70-conditional-verification.md) —

--- a/docs/agent/policy/lean-statement-freeze.md
+++ b/docs/agent/policy/lean-statement-freeze.md
@@ -78,11 +78,39 @@ python3 scripts/check_elaboration_drift.py --dump out.json --raw    # on each tr
 python3 scripts/check_elaboration_drift.py --compare old.json new.json
 python3 scripts/check_elaboration_drift.py --classify old.json new.json
 
-# the standing check, and what CI runs on every branch that touches Lean
+# the standing check; run it by hand on any branch, at any time
 python3 scripts/check_elaboration_drift.py --dump out.json --raw
 python3 scripts/check_elaboration_drift.py --compare \
   docs/status/elab-baseline-v4330.json out.json --fatal silent
 ```
+
+**CI runs that pair on toolchain migrations, both schedules, release tags and
+manual runs — not on an ordinary pull request.** The dump elaborates the whole
+environment: 342 s and 2.2 GB measured, the largest single step there was on an
+ordinary pull request. A migration is decided by `lean-toolchain`,
+`lakefile.toml`, `lake-manifest.json` or a baseline dump moving, so the check
+still fires on the pull request that bumps the toolchain, before the merge. The
+nightly cron bounds how long a silent change can sit unnoticed to a day; the
+weekly one exists for the CDN-drift case that arrives with no commit attached.
+
+**This is a trade, not a free saving.** The dominant causes of silent drift are
+environmental and all still gated. But an ordinary atlas pull request can
+produce it too: adding a typeclass instance changes resolution for declarations
+nobody edited, and so can an attribute, a notation, or a change to a
+definition's implicit arguments. That case now waits for the nightly run rather
+than blocking the pull request — an exposure window of a day instead of zero. It
+has never been observed firing that way here, and the maintainer took the trade
+against a certain 342 s on every Lean-touching PR. If nightly starts catching
+things a pull request introduced, the trade is wrong.
+
+So it is *not* a check you may assume ran on the branch in front of you. If you
+added an instance, an attribute or a notation, or moved anything else that could
+shift the elaborated environment, run the pair above yourself.
+
+[`verification-scheduling.md`](../../provenance/verification-scheduling.md)
+records the decision, the cost of every other check in the same CI job, and the
+rule the gating follows — a check runs at the frequency of the cause it detects,
+not at the frequency of the files it reads.
 
 Dump `--raw`, which keeps the normal form instead of a digest of it, and commit
 that. A hashed dump halves to ~3 MB and loses the only thing `--classify` can
@@ -119,9 +147,12 @@ That bucket is also the only one a branch can be **gated** on, which is what
 `--fatal silent` selects. A plain `--compare` fails on any movement at all —
 the right question for a migration, and red on every ordinary pull request,
 since adding statements is what a branch is for. A declaration whose printed
-type is unchanged cannot have changed meaning through an edit, so a silent
-change is never work anyone asked for, and CI holds this tree to
-`docs/status/elab-baseline-v4330.json` on that bucket alone. It catches what no
+type is unchanged cannot have changed meaning through an edit **to itself**, so
+a silent change is never work anyone asked for, and CI holds this tree to
+`docs/status/elab-baseline-v4330.json` on that bucket alone. Read that
+restriction precisely: an edit *elsewhere* can still move it — a new instance
+changes resolution for declarations nobody touched — which is why the bucket is
+gateable without being empty on an ordinary branch. It catches what no
 source-reading check can: a Mathlib rebuild against a moved artifact, an
 upstream alias, a different instance chosen.
 

--- a/docs/provenance/verification-scheduling.md
+++ b/docs/provenance/verification-scheduling.md
@@ -1,0 +1,115 @@
+# What verification runs where, and why
+
+**What this file is.** A record of how CI verification is scheduled, and of the
+reasoning behind it. Every check here could in principle run on every pull
+request. Some take seconds; two take between five minutes and half an hour, and
+those two are gated. This file gives the trigger for each and the coverage each
+gating forgoes, so that a deliberate budget can be told apart from an oversight
+and so that revisiting one of these decisions means engaging with a stated
+reason.
+
+It is not an inventory of checks.
+[`workflow-validation.md`](../agent/policy/workflow-validation.md) covers what to
+run before a commit; this covers what CI runs, and when.
+
+## The rule
+
+**A check runs at the frequency of the cause it detects, not at the frequency of
+the files it reads.**
+
+A file-extension trigger is the natural first choice, and it misallocates cost.
+A check wired to "any `.lean` file changed" runs most often on the pull requests
+least able to trigger it, while the event that genuinely produces its failure —
+a moved pin, a rebuilt dependency — gets no additional attention. Matching the
+trigger to the cause corrects both halves at once.
+
+Two properties follow.
+
+**Throughput.** An ordinary pull request should complete in minutes. The
+30-minute budget on the `lean` job is a ceiling rather than a target, and a
+single 342-second step consumes a fifth of it.
+
+**Contained risk, rather than no risk.** Gating a check does not prevent the
+failure it looks for. What it does is bound the time such a failure can go
+unnoticed, and each gating below states that bound explicitly. A gating with no
+stated bound would amount to dropping the check, and neither of the two here
+does that.
+
+## The ladder
+
+Measured figures, not estimates. Times vary by runner; the ratios do not.
+
+| Check | Cost | Runs on | Cause it detects |
+|---|---|---|---|
+| `agent_gate.sh` (schema, views, paths, shape suite) | seconds | **everything**, unfiltered | a ledger, view or path that no longer matches the tree |
+| `check_elaboration_drift.py --classify` (inside the cheap gate) | ~1 s, no toolchain | **everything** | a substitution class widened or a committed dump edited |
+| no-op `lake build` | ~4 s | any Lean-touching change | a broken tree |
+| `check_print_axioms.py`, `axiom-audit` | ~40 s | any Lean-touching change | a declaration that stopped being proved |
+| elaboration adjudication anchors (`.lean`) | ~4 s | any Lean-touching change | a later toolchain breaking an equality a recorded verdict rests on |
+| `report_consumers.py` | ~2 s | any Lean-touching change | a stale reuse report |
+| **`check_elaboration_drift.py --dump` + `--compare --fatal silent`** | **342 s, 2.2 GB** | **migration, both schedules, release tags, manual** | a declaration whose printed type is unchanged and whose *elaborated* type moved |
+| **`leanchecker` kernel replay** | **1961 s over 239 modules** | **nightly cron, release tags, manual** | an environment built by metaprogramming rather than by proving |
+
+The two bold rows are the gated ones. Everything above them is cheap enough that
+gating would cost more in reasoning than it saves in runtime.
+
+Runner and budget follow the same split: workflow dispatch, release tags and the
+nightly `15 3 * * *` cron get the self-hosted `leanchecker` runner and a
+75-minute budget; everything else gets `ubuntu-latest` and 30 minutes. The
+weekly `0 6 * * 1` cron is an ordinary hosted run.
+
+## The decision this file was written for
+
+### `check_elaboration_drift` — dump and compare
+
+| | |
+|---|---|
+| **Initial** | `if: steps.filter.outputs.run_lean == 'true'` — every pull request that touched a `.lean` file, a `lakefile`, a manifest, or one of several scripts. |
+| **Final** | Toolchain migrations, both schedules, release tags, and `workflow_dispatch`. Migration is decided from the diff: `lean-toolchain`, `lakefile.toml`, `lake-manifest.json`, or a baseline dump moved. |
+| **Reason** | The check was **built for a migration**. It exists because on a toolchain bump the dangerous change is the one where the source does not move — an upstream rename behind an alias, a different instance chosen, a definition made reducible — and every other check here reads source. Its cost matches that origin: it elaborates the whole environment, 342 s and 2.2 GB on an idle 12-core host against an already-built tree, slower on a two-core hosted runner. That made it the largest single step on an ordinary pull request, and it was triggered by a file extension rather than by the event it was built for. |
+| **Check** | `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` parses; the step's `if:` names `run_migration`, `schedule`, `workflow_dispatch` and `refs/tags/v`. |
+
+**Why `lakefile.toml` is in the migration pattern on its own account.** The
+manifest records resolved revisions, so a `rev` change reaches it. `leanOptions`
+— `autoImplicit`, `pp.*`, `maxHeartbeats` — do not: they change elaboration with
+no manifest movement at all. A pattern that trusted the manifest alone would
+gate out the one edit in that file most likely to move an elaborated type.
+
+**What the change forgoes.** Silent drift arises predominantly from the
+environment moving beneath unchanged source, and every cause of that kind
+remains gated. An ordinary pull request can nonetheless produce it: adding a
+typeclass instance alters resolution for declarations nobody edited, as can a
+new attribute, a notation, or a change to a definition's implicit arguments. In
+each case the printed type is unchanged while the elaborated type is not.
+
+Those cases now surface on the nightly run rather than blocking the pull request
+that introduced them, which puts **the detection window at one day**. No such
+case has been observed here, and 342 s on every Lean-touching pull request is a
+certain cost weighed against an uncertain one.
+
+**What would overturn this.** If the nightly run begins reporting silent changes
+traceable to a pull request, rather than to a toolchain or dependency movement,
+the balance assumed here does not hold and the step should return to running on
+every Lean pull request. That is the observation worth watching, and the one
+that should settle the question.
+
+### `leanchecker` — the same decision, taken earlier
+
+Gated to the nightly cron, release tags and manual runs since before this file
+existed, for the same reason and with the same shape of window. Its own comment
+carries the argument that release tags alone would leave it effectively unrun,
+which is why the nightly cron is what keeps it honest. The elaboration-drift
+gating above deliberately mirrors it, with `run_migration` added because that is
+the event the drift check answers to and the kernel replay does not.
+
+## Applying this to a future check
+
+Two gated checks, two stated windows, one rule.
+
+**Adding an expensive check.** Identify the cause it detects and gate on that.
+If no cause can be named more precisely than "the tree changed", the check is
+either cheap enough for the standard gate or does not belong in CI at all.
+
+**Removing a gating.** State which window closes as a result, and what the check
+costs on every pull request. Both numbers belong in the change that makes it, so
+that the next reader can weigh the same trade this file weighed.


### PR DESCRIPTION
## What this changes

The whole-environment elaboration dump (`check_elaboration_drift.py --dump` +
`--compare --fatal silent`) ran on every pull request that touched a `.lean`
file. It now runs on toolchain migrations, both schedules, release tags and
manual runs.

| Trigger | Before | After |
|---|---|---|
| ordinary Lean pull request | runs — **342 s, 2.2 GB** | skipped |
| toolchain migration | runs | **runs, on the PR that does it** |
| nightly cron | runs | runs |
| weekly cron | runs | runs |
| release tag / `workflow_dispatch` | runs | runs |

Migration is decided from the diff: `lean-toolchain`, `lakefile.toml`,
`lake-manifest.json`, or a baseline dump moved. That is the same rule
`check_migration_adjudicated.py` applies — by the toolchain rather than by
anybody's intent — so a branch that bumps a pin by accident is caught like one
that means to.

`lakefile.toml` is in the pattern on its own account, not only through the
manifest. The manifest records resolved revisions, so a `rev` change reaches it;
`leanOptions` such as `autoImplicit` or `pp.*` do not, and those change
elaboration with no manifest movement at all.

## Why

The check was **built for a migration**. It exists because on a toolchain bump
the dangerous change is the one where the source does not move — an upstream
rename behind an alias, a different instance chosen, a definition made
reducible, a Mathlib rebuilt against a moved CDN artifact — and every other
check in this repository reads source. Its cost matches that origin: it
elaborates the whole environment, 342 s and 2.2 GB on an idle 12-core host
against an already-built tree, slower on a two-core hosted runner. Against the
`lean` job's 30-minute budget it was the largest single step on an ordinary pull
request.

It was gated on a file extension rather than on the event it was built for, so
it spent most of its budget where it had least to find. A recent example: on
#64, an ordinary ledger pull request, it ran for its full cost and reported
*"nothing changed meaning behind an unchanged printed type, across 5994
declarations compared"*.

## What this forgoes

**This is a trade, not a free saving**, and the change records it as one.

Silent drift arises predominantly from the environment moving beneath unchanged
source, and every cause of that kind is still gated. An ordinary pull request
can nonetheless produce it: adding a typeclass instance alters resolution for
declarations nobody edited, as can a new attribute, a notation, or a change to a
definition's implicit arguments. In each case the printed type is unchanged
while the elaborated type is not.

Those cases now surface on the nightly run rather than blocking the pull request
that introduced them. **The detection window is one day.** No such case has been
observed in this repository, and 342 s on every Lean-touching pull request is a
certain cost weighed against an uncertain one.

**What would overturn this.** If the nightly run begins reporting silent changes
traceable to a pull request, rather than to a toolchain or dependency movement,
the balance assumed here does not hold and the step should return to running on
every Lean pull request.

## The record

`docs/provenance/verification-scheduling.md` is new, and is where this decision
lives. It is deliberately wider than one step, so the next expensive check is
not wired the same way:

- **The rule** — a check runs at the frequency of the cause it detects, not at
  the frequency of the files it reads.
- **The cost ladder** for every check in the `lean` job, measured: cheap gate
  (seconds), `--classify` (~1 s, no toolchain), no-op `lake build` (~4 s), axiom
  checks (~40 s), adjudication anchors (~4 s), reuse report (~2 s), the
  elaboration dump (342 s), the `leanchecker` replay (1961 s over 239 modules).
  Only the last two are gated.
- **The runner and budget split** — `workflow_dispatch`, release tags and the
  nightly `15 3 * * *` cron get the self-hosted runner and 75 minutes;
  everything else, the weekly cron included, gets `ubuntu-latest` and 30.
- **The window each gating leaves open**, and how to add or remove a gating.

`ci.yml` and `lean-statement-freeze.md` both link to it, so a future reader
changing a trigger meets the reasoning before the YAML.

## Two corrections to existing text

`lean-statement-freeze.md` described this pair as *"what CI runs on every branch
that touches Lean"*. Now false; it states the schedule, the trade, and that this
is no longer a check you may assume ran on the branch in front of you.

The same file said *"a declaration whose printed type is unchanged cannot have
changed meaning through an edit"*. True only of an edit **to that declaration**;
an edit elsewhere can still move it. Reading it as a claim about branches is
what made the first draft of this change overstate its own safety, so the
sentence now carries the restriction and the counterexample.

## Verification

- `scripts/agent_gate.sh` full — green.
- `.github/workflows/ci.yml` parses as YAML.
- The step's `if:` names `run_migration`, `schedule`, `workflow_dispatch` and
  `refs/tags/v`.
- Migration pattern checked against `lean-toolchain`, `lakefile.toml`,
  `lake-manifest.json` and `docs/status/elab-baseline-*.json` (match) and
  against a `.lean` file, `README.md` (no match).
- **This pull request is its own first test.** It edits `ci.yml`, so `run_lean`
  is true and the whole Lean job runs; it moves no pin, so `run_migration` is
  false and the elaboration dump should be **skipped**. If that step runs here,
  the gating is wrong.

## Scope

No check is removed and no detection path is dropped. One trigger narrows, with
the window it opens stated and a falsifier recorded. Independent of #64 — a
different hunk of `ci.yml`, no conflict.
